### PR TITLE
Add concept catalog and concept-skill map for cohesive IDD curation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,55 @@
 # Intention-Driven Design
 
-Single source of truth for intention-driven development artifacts:
-- reusable agent skills
-- core principles and operating doctrine
-- repeatable project scaffolding
+Single source of truth for IDD philosophy, concepts, and agent skills.
+
+This repo serves two roles:
+1. **Concept library** — canonical definitions of every IDD concept, principle,
+   and operating rule.
+2. **Skill source** — reference skill implementations that embody the concepts
+   and can be converted to any agent platform's native format.
 
 ## Repository layout
 
-- `skills/`: canonical IDD-focused skills (method, narrative, contracts, workflow)
-- `technical-skills/`: technical implementation skills (Angular, Spring, platform-specific)
-- `docs/idd/`: formalized method artifacts
-- `tools/`: sync/validation utilities
+```
+docs/idd/
+├── manifesto.md             Core principles (the "why")
+├── agent-operating-contract.md  Non-negotiable agent rules
+├── project-template.md      Artifact spine and delivery loop
+├── concepts.md              Atomic concept catalog (C1–C14)
+└── concept-skill-map.md     Which concepts each skill carries
+
+skills/                      Reference IDD skill implementations
+├── solution-narrative/      Personas, journeys, stories
+├── domain-modeling/         Entities, aggregates, business rules
+├── behavior-contract/       BDD features, OpenAPI contracts, fixtures
+├── e2e-journey-testing/     Playwright journey tests
+├── workflow-guide/          Meta-skill: when to use which skill
+├── .system/                 Platform skills (skill-creator, skill-installer)
+└── HARMONIZATION.md         Merge history from initial unification
+
+tools/                       Sync and validation utilities
+├── sync-skills.sh           Push skills to agent runtimes
+└── diff-skills.sh           Detect drift between runtime copies
+```
+
+## How concepts and skills relate
+
+Concepts (`docs/idd/concepts.md`) are the atomic units of IDD philosophy.
+Skills (`skills/`) are operational implementations that embody subsets of those
+concepts. The mapping between them is tracked in
+`docs/idd/concept-skill-map.md`.
+
+When converting a skill to a new agent platform:
+1. Check which concepts the skill carries (the map).
+2. Use the concept catalog as the acceptance checklist.
+3. Ensure no concept is lost or contradicted in translation.
 
 ## Source of truth policy
 
-1. `skills/` and `technical-skills/` in this repository are authoritative.
-2. Personal runtime folders (`~/.codex/skills`, `~/.claude/skills`) are downstream copies.
-3. Proposed skill changes should be committed here first, then synced out.
+1. Concept definitions in `docs/idd/` are authoritative for meaning.
+2. Skills in `skills/` are authoritative for operational implementation.
+3. Runtime copies (`~/.codex/skills`, `~/.claude/skills`) are downstream — never edit there first.
+4. Proposed changes are committed here, then synced out via `tools/sync-skills.sh`.
 
 ## Initial harmonization baseline
 

--- a/docs/idd/concept-skill-map.md
+++ b/docs/idd/concept-skill-map.md
@@ -1,0 +1,61 @@
+# Concept → Skill Map
+
+How IDD concepts distribute across skills. Use this when:
+- **Creating a new skill**: identify which concepts it must embody.
+- **Converting a skill to another agent format**: verify no concept is lost.
+- **Updating a concept**: find every skill that needs to reflect the change.
+
+## Matrix
+
+| Concept | solution-narrative | domain-modeling | behavior-contract | e2e-journey-testing | workflow-guide |
+|---------|:--:|:--:|:--:|:--:|:--:|
+| C1  Intent Precedes Code        | **primary** | | | | referenced |
+| C2  Models Are Artifacts        | **primary** | **primary** | **primary** | | referenced |
+| C3  Contracts at Boundaries     | | | **primary** | referenced | referenced |
+| C4  Assumptions Executable      | | | **primary** | **primary** | referenced |
+| C5  Fast Honest Feedback        | | | | **primary** | referenced |
+| C6  Protect Human Cognition     | referenced | referenced | referenced | referenced | referenced |
+| C7  Evolution Preserves Meaning | | referenced | referenced | | referenced |
+| C8  Traceability Chain          | **primary** | referenced | **primary** | **primary** | **primary** |
+| C9  Narrative-First             | **primary** | | | | referenced |
+| C10 Domain as Formal Model      | | **primary** | referenced | | referenced |
+| C11 Layered Artifact Spine      | referenced | referenced | referenced | referenced | **primary** |
+| C12 Done Means Verified         | | | referenced | **primary** | referenced |
+| C13 Fix Forward                 | | | referenced | referenced | **primary** |
+| C14 Agent Non-Negotiables       | referenced | referenced | referenced | referenced | referenced |
+
+**primary** = skill is the main vehicle for this concept; it defines templates and enforces it.
+**referenced** = skill mentions or depends on the concept but doesn't define it.
+
+## Concept density by skill
+
+| Skill | Primary concepts | Referenced concepts |
+|-------|:---:|:---:|
+| solution-narrative   | C1, C2, C8, C9        | C6, C11, C14 |
+| domain-modeling      | C2, C10                | C6, C7, C8, C11, C14 |
+| behavior-contract    | C2, C3, C4, C8        | C7, C10, C11, C12, C13, C14 |
+| e2e-journey-testing  | C4, C5, C8, C12       | C3, C6, C11, C13, C14 |
+| workflow-guide       | C8, C11, C13           | C1, C3, C4, C5, C6, C7, C9, C10, C12, C14 |
+
+## Conversion checklist
+
+When converting a skill to a new agent platform:
+
+1. Look up the skill in the matrix above.
+2. For each **primary** concept, verify the converted skill:
+   - Defines or enforces the concept explicitly.
+   - Includes relevant templates/schemas from the original skill.
+3. For each **referenced** concept, verify the converted skill:
+   - Does not contradict the concept.
+   - Mentions it where relevant (e.g., traceability headers in output templates).
+4. Cross-reference concept definitions in [concepts.md](concepts.md) if wording
+   diverges — the catalog is authoritative.
+
+## Impact analysis
+
+When updating a concept definition in `concepts.md`:
+
+1. Find the concept row in the matrix.
+2. Update every skill marked **primary** — these define the concept operationally.
+3. Review skills marked **referenced** — they may need wording adjustments.
+4. Run `tools/diff-skills.sh` after syncing to verify no runtime copies diverge.

--- a/docs/idd/concepts.md
+++ b/docs/idd/concepts.md
@@ -1,0 +1,170 @@
+# IDD Concept Catalog
+
+Canonical definitions of every IDD concept. Each concept is defined once here.
+Skills implement subsets of these concepts; the [concept-skill map](concept-skill-map.md)
+tracks which concepts each skill carries.
+
+When converting concepts to a new agent's skill format, use this catalog as the
+acceptance checklist: every concept a skill claims must be faithfully represented
+in the output.
+
+---
+
+## C1 — Intent Precedes Code
+
+No implementation begins without an explicit intent artifact (persona, journey,
+or story). Code is a downstream consequence of declared intent, never the
+starting point.
+
+**Manifesto principle**: 1
+**Artifacts involved**: personas, journeys, stories
+
+---
+
+## C2 — Shared Mental Models Are Artifacts
+
+Understanding lives in versioned documents, not conversations or tribal
+knowledge. If a concept matters, it has a file.
+
+**Manifesto principle**: 2
+**Artifacts involved**: all `specs/` documents
+
+---
+
+## C3 — Contracts Define Reality at Boundaries
+
+API contracts (OpenAPI, Gherkin features) are the authoritative source of truth
+for how systems interact. Implementation must conform to the contract, not the
+other way around.
+
+**Manifesto principle**: 3
+**Artifacts involved**: features, contracts/openapi, fixtures
+
+---
+
+## C4 — Assumptions Become Executable
+
+Every assumption about behavior is expressed as an automated check — BDD
+scenario, contract test, or e2e assertion. Untested assumptions are technical
+debt.
+
+**Manifesto principle**: 4
+**Artifacts involved**: features, fixtures, e2e tests
+
+---
+
+## C5 — Fast Honest Automated Feedback
+
+Verification is evidence-based, not opinion-based. Feedback loops are automated,
+deterministic, and run continuously.
+
+**Manifesto principle**: 5
+**Artifacts involved**: certification/, CI pipelines
+
+---
+
+## C6 — Protect Human Cognition
+
+Agents handle bookkeeping, traceability enforcement, and repetitive artifact
+generation. Humans focus on meaning, tradeoffs, and creative decisions.
+
+**Manifesto principle**: 6
+**Applies to**: agent behavior rules, workflow automation
+
+---
+
+## C7 — Evolution Preserves Meaning
+
+Change is expected. Drift is not. Refactors must preserve declared invariants.
+Artifact references must be updated when upstream artifacts change.
+
+**Manifesto principle**: 7
+**Applies to**: modification workflows, traceability maintenance
+
+---
+
+## C8 — Traceability Chain
+
+Every downstream artifact references its upstream source. The full chain:
+
+```
+Persona → Journey → Story → Feature → Contract → Tests → Evidence
+```
+
+No link in the chain is optional. If an artifact exists, its provenance is
+declared.
+
+**Enforced via**: comment headers, `x-story`/`x-feature`/`x-journey` OpenAPI
+extensions, `_meta` blocks in fixtures, test file headers.
+
+---
+
+## C9 — Narrative-First Requirements
+
+Requirements begin as human stories, not technical specifications. The sequence
+is always: who needs this (persona) → what experience they have (journey) →
+what the system does (story) → how it behaves (feature/contract).
+
+**Skill entry point**: solution-narrative
+**Artifacts produced**: personas, journeys, stories
+
+---
+
+## C10 — Domain as Formal Model
+
+Business concepts are captured in structured, typed artifacts (entity
+definitions, lifecycle state machines, aggregate boundaries) before
+implementation. The model is the shared vocabulary between narrative and code.
+
+**Skill entry point**: domain-modeling
+**Artifacts produced**: entity YAML, lifecycle YAML, aggregate definitions
+
+---
+
+## C11 — Layered Artifact Spine
+
+The project structure follows a fixed layered order. Each layer produces
+artifacts that feed the next:
+
+```
+Narrative  →  Model  →  Contract  →  Implementation  →  Validation
+```
+
+Layers have clear boundaries. Skipping a layer requires explicit justification.
+
+**Defined in**: project-template.md
+**Directory structure**: `specs/` subdirectories mirror the layers
+
+---
+
+## C12 — Done Means Verified
+
+A capability is done when:
+1. Every story references its journey and persona.
+2. Every contract operation references its source story/feature.
+3. Every automated test maps to an explicit intent artifact.
+4. No feature is accepted on manual confidence alone.
+
+**Defined in**: project-template.md (done criteria)
+
+---
+
+## C13 — Fix Forward
+
+When a defect is found, the response is to add the missing specification first
+(feature scenario, contract clause, business rule), then fix the implementation
+to match. Fixing code without updating specs violates traceability.
+
+**Applies to**: bug fix workflows
+
+---
+
+## C14 — Agent Operating Non-Negotiables
+
+Four rules agents must never violate:
+1. No implementation without an explicit intent artifact.
+2. No boundary behavior without a contract artifact.
+3. No merge without verifiable evidence tied to intent.
+4. No silent drift: refactors must preserve declared invariants.
+
+**Defined in**: agent-operating-contract.md


### PR DESCRIPTION
Introduces two new documents to keep IDD philosophy cohesive as concepts
get converted to skills across different agent platforms:

- concepts.md: Atomic definitions of 14 IDD concepts (C1-C14), each
  defined once as the canonical source of truth.
- concept-skill-map.md: Matrix mapping which concepts each skill carries
  (primary vs referenced), with conversion checklist and impact analysis
  guidance.

Updates README to reflect the repo's dual role as concept library and
skill source.

https://claude.ai/code/session_01Fknmv6Ab9VJRbagjotx9A6