### PR TITLE
fix: install lint tools for downstream consumers

### DIFF
--- a/.github/actions/idd-check/action.yml
+++ b/.github/actions/idd-check/action.yml
@@ -54,7 +54,7 @@ runs:
           cd "${{ github.action_path }}/../../.."
           npm ci
         else
-          npm install idd-toolkit
+          npm install idd-toolkit @stoplight/spectral-cli gherkin-lint
         fi
 
     - name: Gather changed specs


### PR DESCRIPTION
## Summary

- The `idd-check` composite action uses `npx spectral lint` and `npx gherkin-lint`, but when running in a downstream repo, only `npm install idd-toolkit` is executed
- `@stoplight/spectral-cli` and `gherkin-lint` are devDependencies of this repo, so they aren't installed transitively via `idd-toolkit`
- This causes `npx spectral` to exit with code 127 (command not found), failing the IDD Validation Suite
- Fix: explicitly install both lint tools alongside `idd-toolkit` in the consumer install path

## Test plan

- [ ] Merge this and re-run the failing IDD check on https://github.com/slusset/edyoucate-ai/pull/95

🤖 Generated with [Claude Code](https://claude.com/claude-code)