### PR TITLE
fix: use scoped package name for spectral npx invocation

### DIFF
--- a/.github/actions/idd-check/action.yml
+++ b/.github/actions/idd-check/action.yml
@@ -112,7 +112,7 @@ runs:
         OPENAPI_RAN=false
         if [ -f "${{ inputs.spectral-ruleset }}" ] && [ -f "$SPECS_DIR/contracts/openapi/api.yaml" ]; then
           OPENAPI_RAN=true
-          npx spectral lint "$SPECS_DIR/contracts/openapi/api.yaml" --ruleset "${{ inputs.spectral-ruleset }}" > /tmp/idd-results/openapi-lint.txt 2>&1
+          npx @stoplight/spectral-cli lint "$SPECS_DIR/contracts/openapi/api.yaml" --ruleset "${{ inputs.spectral-ruleset }}" > /tmp/idd-results/openapi-lint.txt 2>&1
           OPENAPI_EXIT=$?
         fi
         echo "openapi_exit=$OPENAPI_EXIT" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- `npx spectral lint` in the idd-check action resolves to the wrong npm package (`spectral@0.0.0`) instead of `@stoplight/spectral-cli`, causing OpenAPI linting to fail for downstream consumers
- Changed to `npx @stoplight/spectral-cli lint` which correctly resolves the scoped package already installed on the preceding line

## Test plan
- [ ] Consumer repo running idd-check action no longer gets `sh: 1: spectral: not found`
- [ ] OpenAPI linting step runs successfully when `.spectral.yaml` and `api.yaml` are present

🤖 Generated with [Claude Code](https://claude.com/claude-code)