### PR TITLE
Fix fixture validator $ref resolution for nested components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- `validate fixtures`: nested `$ref` composition in `components.schemas`
+  (e.g. `allOf: [{ $ref: '#/components/schemas/Base' }, ...]`) now resolves
+  correctly in both the legacy `_meta.schema` path and the OpenAPI
+  `method/path` path. Previously the validator called `ajv.compile(schema)`
+  in isolation and failed with `can't resolve reference from id #`
+  whenever a named schema referenced a sibling component. The fix
+  pre-registers every `components.schemas.*` entry with its canonical
+  `#/components/schemas/<Name>` as `$id` so Ajv can resolve nested
+  references at compile time. Added regression test
+  `test/fixture-ref-resolution.test.js`.
+
 ## [0.1.0] - 2026-03-07
 
 ### Added

--- a/test/fixture-ref-resolution.test.js
+++ b/test/fixture-ref-resolution.test.js
@@ -1,0 +1,132 @@
+/**
+ * Regression test for the fixture validator's handling of nested `$ref`
+ * composition in OpenAPI component schemas.
+ *
+ * Before the fix, compiling a named schema that used
+ *   allOf: [{ $ref: '#/components/schemas/Base' }, ...]
+ * would fail with:
+ *   "can't resolve reference #/components/schemas/Base from id #"
+ * because Ajv only saw the top-level schema; sibling components were
+ * never registered as named schemas. The fix pre-registers every entry
+ * under `components.schemas` with its canonical `$ref` as `$id` so
+ * Ajv can resolve nested references on compile.
+ *
+ * This test builds a minimal specs/ tree in a temp dir with a contract
+ * that uses allOf composition, adds fixtures that exercise both the
+ * legacy (`_meta.schema`) path and the OpenAPI (`method/path`) path,
+ * and asserts the validator returns zero errors.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const IDD_BIN = path.join(REPO_ROOT, 'bin', 'idd.js');
+
+function runJson(args, opts = {}) {
+  const out = execFileSync(process.execPath, args, {
+    cwd: opts.cwd || REPO_ROOT,
+    encoding: 'utf8',
+  });
+  return JSON.parse(out);
+}
+
+function makeTempSpecsDir() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'idd-fixture-refs-'));
+  const specs = path.join(root, 'specs');
+  fs.mkdirSync(path.join(specs, 'contracts', 'openapi'), { recursive: true });
+  fs.mkdirSync(path.join(specs, 'fixtures'), { recursive: true });
+
+  const openapi = [
+    'openapi: 3.1.0',
+    'info:',
+    '  title: ref-resolution fixture',
+    '  version: 0.0.1',
+    'paths:',
+    '  /widgets:',
+    '    post:',
+    '      operationId: createWidget',
+    '      requestBody:',
+    '        required: true',
+    '        content:',
+    '          application/json:',
+    "            schema: { $ref: '#/components/schemas/WidgetBase' }",
+    '      responses:',
+    "        '201':",
+    '          description: created',
+    '          content:',
+    '            application/json:',
+    "              schema: { $ref: '#/components/schemas/WidgetCreated' }",
+    'components:',
+    '  schemas:',
+    '    WidgetBase:',
+    '      type: object',
+    '      required: [name]',
+    '      properties:',
+    '        name: { type: string }',
+    '    WidgetCreated:',
+    '      allOf:',
+    "        - $ref: '#/components/schemas/WidgetBase'",
+    '        - type: object',
+    '          required: [id]',
+    '          properties:',
+    '            id: { type: string }',
+    '',
+  ].join('\n');
+  fs.writeFileSync(path.join(specs, 'contracts', 'openapi', 'api.yaml'), openapi);
+
+  // Legacy-path fixture: references `WidgetCreated` via `_meta.schema`.
+  // Without the fix, this trips on the nested $ref to WidgetBase.
+  fs.writeFileSync(
+    path.join(specs, 'fixtures', 'legacy-path.json'),
+    JSON.stringify(
+      {
+        _meta: { id: 'legacy-path', type: 'fixture', schema: 'WidgetCreated' },
+        request: { name: 'sample' },
+        response: { name: 'sample', id: 'w_1' },
+      },
+      null,
+      2,
+    ),
+  );
+
+  // OpenAPI-path fixture: uses method+path; the response schema pulled
+  // from the operation is `WidgetCreated`, same composition.
+  fs.writeFileSync(
+    path.join(specs, 'fixtures', 'openapi-path.json'),
+    JSON.stringify(
+      {
+        _meta: { id: 'openapi-path', type: 'fixture' },
+        request: {
+          method: 'POST',
+          path: '/widgets',
+          body: { name: 'sample' },
+        },
+        response: { status: 201, body: { name: 'sample', id: 'w_2' } },
+      },
+      null,
+      2,
+    ),
+  );
+
+  return specs;
+}
+
+test('fixture validator resolves nested $refs in legacy and OpenAPI paths', () => {
+  const specs = makeTempSpecsDir();
+  const result = runJson([IDD_BIN, 'validate', 'fixtures', specs, '--json']);
+
+  assert.deepEqual(
+    result.errors,
+    [],
+    `Expected zero errors, got:\n${result.errors.join('\n')}`,
+  );
+
+  const info = result.info.join('\n');
+  assert.match(info, /legacy-path\.json: valid/);
+  assert.match(info, /openapi-path\.json: valid/);
+});

--- a/tools/validate-fixtures.js
+++ b/tools/validate-fixtures.js
@@ -91,6 +91,42 @@ function createAjv() {
   return ajv;
 }
 
+/**
+ * Pre-register every `components.schemas.*` entry from every OpenAPI
+ * contract in the index as a named Ajv schema keyed by its canonical
+ * `$ref` ("#/components/schemas/<Name>"). This lets nested `$ref`s in
+ * any compiled schema (via `allOf` / `oneOf` / `properties`) resolve
+ * against sibling components without the validator having to inline
+ * them first.
+ *
+ * Without this, validating a schema that uses `allOf: [{ $ref: ... }]`
+ * fails at compile time with "can't resolve reference from id #" because
+ * Ajv only sees the top-level schema. Both the legacy-path
+ * (`validateLegacyFixture`) and the OpenAPI-path (`validateOpenApiFixture`)
+ * compile schemas extracted from components in isolation; both benefit
+ * from this registration.
+ *
+ * Malformed individual schemas are skipped so the per-fixture compile
+ * can still surface a precise error instead of failing the whole run.
+ */
+function registerComponentSchemas(ajv, index) {
+  for (const contract of index.openapiContracts) {
+    const components = contract.document && contract.document.components;
+    const schemas = components && components.schemas;
+    if (!schemas || typeof schemas !== 'object') continue;
+    for (const [name, schema] of Object.entries(schemas)) {
+      const ref = `#/components/schemas/${name}`;
+      if (ajv.getSchema(ref)) continue; // duplicate across contracts — first wins
+      if (!schema || typeof schema !== 'object') continue;
+      try {
+        ajv.addSchema({ ...schema, $id: ref });
+      } catch {
+        // Malformed schema — let the per-fixture compile surface a precise error.
+      }
+    }
+  }
+}
+
 function validateWithSchema(ajv, schema, value, label) {
   try {
     const validate = ajv.compile(schema);
@@ -401,6 +437,7 @@ function main() {
   const index = buildContractIndex(results);
   const schemas = getLegacySchemas(index);
   const ajv = createAjv();
+  registerComponentSchemas(ajv, index);
 
   if (index.contracts.length === 0 && results.errors.length === 0) {
     results.info.push('Fixture schema validation skipped because no contract artifacts are available');


### PR DESCRIPTION
## Problem

`validate-fixtures.js` calls `ajv.compile(schema)` in isolation on whichever named schema the fixture targets. When that schema composes sibling components via `allOf: [{ \$ref: '#/components/schemas/Base' }, ...]` (a common OpenAPI pattern), Ajv has no way to resolve the reference and throws:

\`\`\`
Response schema could not be compiled: can't resolve reference #/components/schemas/Base from id #
\`\`\`

This affects both validator code paths — the legacy `_meta.schema` path and the OpenAPI `method/path` path — because both end up calling `validateWithSchema` → `ajv.compile`. Real repos start hitting this the moment their OpenAPI contract evolves past flat schemas, which happens quickly.

## Fix

Add `registerComponentSchemas(ajv, index)`, called once in `main()` right after the Ajv instance is created. It iterates every OpenAPI contract in the index and calls:

\`\`\`js
ajv.addSchema({ ...schema, \$id: '#/components/schemas/<Name>' })
\`\`\`

for each `components.schemas.*` entry. Ajv now resolves nested `\$ref`s at compile time without requiring callers to inline them or register them manually. Malformed individual schemas are skipped so the per-fixture compile can still surface a precise error.

## Verification

### New regression test
[\`test/fixture-ref-resolution.test.js\`](test/fixture-ref-resolution.test.js) — builds a minimal specs/ tree with an \`allOf: [\$ref]\` schema and fixtures exercising both code paths, asserts zero errors. Fails before the patch, passes after.

### Against a real-world repo
Validated on [\`slusset/edyoucate-ai\`](https://github.com/slusset/edyoucate-ai) before/after:

| Error category | Before | After |
|---|---|---|
| \`can't resolve reference\` (ref composition) | 20 | **0** |
| \`operation not found\` (unrelated) | 5 | 5 |

### Full suite

\`\`\`
$ npm test
# tests 6
# pass 6
# fail 0
\`\`\`

## Scope

- Zero breaking changes. Behavior for fixtures that already passed remains identical (Ajv's `getSchema(ref)` check skips duplicates, and malformed schemas fall back to the existing per-fixture compile error).
- One new helper, one new test. `createAjv` is unchanged; all other validator paths untouched.
- CHANGELOG entry added under `[Unreleased]` > `Fixed`.

## Why this matters

Downstream consumers (e.g. edyoucate-ai, which surfaced the issue) currently have to either:
1. Migrate every affected fixture to the `method/path` format AND update journey-map templates that reference fixture field paths — substantial work with real cascade risk, or
2. Narrow their CI \`idd-check\` action to skip \`fixtures\` — hides real errors.

This fix removes the need for (1), keeping fixture-shape migration decisions orthogonal to the validator's behavior on composed schemas.