### PR TITLE
Add agent role extension and methodology change process

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ Agentic coding tools are remarkably capable at execution but have a subtle failu
 
 The result is a framework where AI agents can autonomously implement, verify, and evolve software while humans focus on meaning, tradeoffs, and creative decisions.
 
+IDD can also be extended through explicit agent roles: bounded execution
+contracts that let multiple agents develop the methodology or a target system in
+parallel without breaking traceability.
+
 ## How it works
 
 ```
@@ -201,6 +205,25 @@ IDD's narrative, model, and contract skills stay stack-agnostic. Repositories ca
 
 The `idd-workflow` skill should load that overlay before picking backend/frontend implementation skills. If the overlay is missing, it should warn, offer to scaffold one, and continue with explicit assumptions instead of blocking the session.
 
+## Agent roles as an IDD extension
+
+When work is split across multiple humans or agents, define a role contract for
+each actor:
+
+- owned boundary
+- required inputs
+- decisions it may make autonomously
+- outputs it must produce
+- invariants it must preserve
+- handoff target and success evidence
+
+This extends IDD through agency rather than bypassing it. The role governs how
+work is executed; the artifact spine still governs what must remain true.
+
+See [Agent Role](docs/idd/agent-role.md) and [Agent Operating Contract](docs/idd/agent-operating-contract.md).
+For the broader systems view, see [Self-Evolving Engineering Ecosystem](docs/idd/self-evolving-ecosystem.md).
+For governing changes to IDD itself, see [Methodology Change Process](docs/idd/methodology-change-process.md).
+
 ## Skills
 
 | Skill | Purpose | Invocation |
@@ -235,9 +258,13 @@ bin/
 
 docs/idd/                    IDD philosophy and concept library
 ├── manifesto.md             Core principles (the "why")
-├── concepts.md              Atomic concept catalog (C1–C14)
+├── concepts.md              Atomic concept catalog (C1–C16)
 ├── concept-skill-map.md     Which concepts each skill carries
 ├── agent-operating-contract.md  Non-negotiable agent rules
+├── agent-role.md            Agent-role extension for orchestrated agency
+├── self-evolving-ecosystem.md  Runtime + world-model framing around IDD
+├── methodology-change-process.md  How IDD changes should follow IDD
+├── templates/               Reusable methodology templates
 ├── project-template.md      Artifact spine and delivery loop
 └── certification-guide.md   Evidence standards and templates
 

--- a/docs/idd/agent-operating-contract.md
+++ b/docs/idd/agent-operating-contract.md
@@ -18,3 +18,16 @@
 - Prefer deterministic checks over narrative claims.
 - Report confidence as evidence-backed findings, not opinions.
 - Keep humans focused on meaning and tradeoffs, not bookkeeping.
+
+## Agent role protocol
+
+Before parallel or delegated work begins, define the active role contract:
+
+- Role name and owned boundary
+- Required upstream artifacts and invariants
+- Allowed decisions and prohibited changes
+- Expected outputs and handoff target
+- Success evidence for closing the role
+
+If a role discovers a gap outside its authority, it must route the change to the
+correct upstream layer instead of improvising across boundaries.

--- a/docs/idd/agent-role.md
+++ b/docs/idd/agent-role.md
@@ -1,0 +1,79 @@
+# Agent Role
+
+Agent role is an IDD extension for orchestrated agency. It defines how a human
+or agent participates in delivery without weakening the traceability chain.
+
+## Definition
+
+An agent role is a bounded execution contract that states:
+
+- what responsibility the actor owns
+- which intent artifacts it must honor
+- what decisions it may make autonomously
+- what outputs it must produce
+- how it hands work to the next role
+
+Roles are not job titles. They are operational boundaries. A single agent may
+perform multiple roles sequentially, but each role must still have a clear
+contract.
+
+## Why IDD needs it
+
+IDD already defines what artifacts must exist and how they trace back to human
+intent. Multi-agent execution introduces a second problem: how work is divided
+without losing that intent.
+
+Agent role closes that gap. It lets the methodology evolve through agency while
+keeping every actor aligned to the same declared meaning.
+
+## Role contract
+
+Use this minimum structure when defining a role:
+
+```yaml
+role: contract-steward
+mission: Keep boundary behavior aligned with declared stories and features.
+owns:
+  - specs/features/
+  - specs/contracts/openapi/
+inputs:
+  - specs/stories/
+  - specs/models/
+must_preserve:
+  - capability scope
+  - traceability references
+may_change:
+  - feature scenarios
+  - OpenAPI operations
+must_not_change:
+  - persona intent without narrative update
+handoff_to:
+  - implementation-role
+success_evidence:
+  - changed artifacts reference upstream sources
+  - validation passes
+```
+
+## Actionable adoption steps
+
+1. Define roles before parallelizing work.
+   - Name each role, its owned boundary, and the artifacts it may edit.
+2. Put role contracts in the orchestrator handoff.
+   - Include inputs, outputs, invariants, and success evidence.
+3. Route decisions back to the right upstream layer.
+   - If a role discovers a narrative, model, or contract gap, update the spec
+     before implementation.
+4. Certify role outputs, not just code changes.
+   - The role succeeded only when its outputs still trace to intent and remain
+     certifiable.
+
+## Example role set
+
+- Narrative role: refines personas, journeys, and stories
+- Model role: maintains entities, rules, and lifecycles
+- Contract role: owns features, API contracts, and fixtures
+- Implementation role: changes code to satisfy upstream contracts
+- Validation role: proves journeys and contract behavior
+- Certification role: closes the chain with evidence
+
+These roles do not replace IDD layers. They operationalize them.

--- a/docs/idd/concept-skill-map.md
+++ b/docs/idd/concept-skill-map.md
@@ -24,6 +24,7 @@ How IDD concepts distribute across skills. Use this when:
 | C13 Fix Forward                 | | | referenced | referenced | referenced | **primary** | **primary** |
 | C14 Agent Non-Negotiables       | referenced | referenced | referenced | referenced | referenced | **primary** | referenced |
 | C15 Capability as Cert Unit     | referenced | | | | **primary** | referenced | **primary** |
+| C16 Agent Role as Exec Contract | referenced | referenced | referenced | referenced | referenced | referenced | **primary** |
 
 **primary** = skill is the main vehicle for this concept; it defines templates and enforces it.
 **referenced** = skill mentions or depends on the concept but doesn't define it.
@@ -36,13 +37,13 @@ The pr-review skill is also cross-cutting — it enforces IDD compliance at the 
 
 | Skill | Primary concepts | Referenced concepts |
 |-------|:---:|:---:|
-| solution-narrative   | C1, C2, C8, C9        | C6, C11, C14, C15 |
-| domain-modeling      | C2, C10                | C6, C7, C8, C11, C14 |
-| behavior-contract    | C2, C3, C4, C8        | C7, C10, C11, C12, C13, C14 |
-| e2e-journey-testing  | C4, C5, C8, C12       | C3, C6, C11, C13, C14 |
-| certification        | C5, C8, C12, C15      | C4, C13, C14 |
-| pr-review            | C5, C8, C13, C14      | C12, C15 |
-| idd-workflow       | C8, C11, C13, C15     | C1, C3, C4, C5, C6, C7, C9, C10, C12, C14 |
+| solution-narrative   | C1, C2, C8, C9        | C6, C11, C14, C15, C16 |
+| domain-modeling      | C2, C10                | C6, C7, C8, C11, C14, C16 |
+| behavior-contract    | C2, C3, C4, C8        | C7, C10, C11, C12, C13, C14, C16 |
+| e2e-journey-testing  | C4, C5, C8, C12       | C3, C6, C11, C13, C14, C16 |
+| certification        | C5, C8, C12, C15      | C4, C13, C14, C16 |
+| pr-review            | C5, C8, C13, C14      | C12, C15, C16 |
+| idd-workflow       | C8, C11, C13, C15, C16 | C1, C3, C4, C5, C6, C7, C9, C10, C12, C14 |
 
 ## Conversion checklist
 

--- a/docs/idd/concepts.md
+++ b/docs/idd/concepts.md
@@ -199,3 +199,19 @@ capabilities; capabilities enumerate their constituent artifacts.
 (certification workflow)
 **Related concepts**: C8 (closes the chain at scope level), C11 (adds a
 grouping layer above the spine), C12 (defines what "done" means for)
+
+---
+
+## C16 — Agent Role as Execution Contract
+
+When work is distributed across humans or agents, each actor must have a
+bounded role contract: owned scope, required inputs, permitted decisions,
+expected outputs, preserved invariants, and explicit handoff targets.
+
+Agent role extends IDD through agency without changing the artifact spine. It
+defines how methodology is executed, not what intent means. Roles must route
+ambiguity back to the correct upstream layer instead of improvising across
+boundaries.
+
+**Applies to**: orchestration, multi-agent delivery, handoff design, review
+**Defined in**: agent-role.md, agent-operating-contract.md, idd-workflow

--- a/docs/idd/methodology-change-process.md
+++ b/docs/idd/methodology-change-process.md
@@ -1,0 +1,116 @@
+# Methodology Change Process
+
+This repository should apply Intention-Driven Design to changes in IDD itself.
+
+Methodology changes are not exempt from the methodology. They must move through
+an explicit path from intent to evidence before they become canonical guidance.
+
+## Why this exists
+
+When exploring new practices such as eval frameworks, harnesses, or orchestration
+patterns, the easiest failure mode is to let experiments silently become doctrine.
+
+This process prevents that drift by separating:
+
+- exploration
+- provisional adoption
+- canonical methodology
+
+## Change states
+
+### 1. Exploratory
+
+Used for trying a new idea such as an eval harness, workflow pattern, or agent
+coordination approach.
+
+Requirements:
+
+- a short design note or proposal describing the problem and intent
+- a clearly named experiment status
+- no claim that the practice is yet part of canonical IDD
+
+Typical outputs:
+
+- design notes in `docs/idd/`
+- templates in `docs/idd/templates/`
+- example workflows or trial notes
+
+### 2. Provisional
+
+Used when an exploratory idea has enough evidence to guide work, but has not yet
+earned full promotion into the core methodology.
+
+Requirements:
+
+- explicit scope of what is being adopted
+- at least one worked example
+- evidence describing what the experiment changed or clarified
+- human approval for provisional use
+
+Typical outputs:
+
+- updates to workflow skills
+- PR review guidance
+- reusable templates
+
+### 3. Canonical
+
+Used when the practice is accepted as part of IDD itself.
+
+Requirements:
+
+- clear intent artifact
+- defined scope and affected repository surfaces
+- repeatable evidence
+- explicit human approval
+- updates to top-level documentation such as `README.md`
+
+Canonical changes affect how the repository teaches or enforces IDD.
+
+## Required artifact path
+
+Methodology changes should follow this path:
+
+1. Intent
+   Capture the change as a design note, story, or proposal artifact.
+2. Scope
+   Define the affected methodology boundary: docs, skills, tools, CI, governance.
+3. Contract
+   Describe the expected workflow or rule change.
+4. Implementation
+   Update docs, skills, templates, or tooling.
+5. Verification
+   Show a worked example, eval run, or review outcome.
+6. Evidence
+   Record why the change should remain exploratory, provisional, or become canonical.
+
+## Lightweight governance rules
+
+These are the minimum rules for this repository:
+
+1. No methodology change merges without an intent artifact.
+2. No workflow or skill change merges without at least one worked example or explicit rationale for why example-based verification is not yet possible.
+3. No promotion from exploratory to canonical without explicit human approval.
+4. Experiments may inform the methodology, but they do not redefine it on their own.
+
+## Eval frameworks and harnesses
+
+When evaluating a new framework or harness such as deer-flow:
+
+1. Treat it as exploratory first.
+2. Document what question the eval answers.
+3. Record which failure modes or decisions the eval is meant to expose.
+4. Keep the harness separate from canonical IDD language until evidence exists.
+5. Promote only the lessons that remain legible to the IDD artifact spine.
+
+The harness is not the methodology. It is evidence-producing infrastructure.
+
+## PR review expectations
+
+PRs that change the methodology should answer three questions:
+
+1. What intent justifies this change?
+2. What methodology boundary is in scope?
+3. What evidence supports the proposed promotion state?
+
+If a PR cannot answer those questions yet, the change should remain exploratory.

--- a/docs/idd/project-template.md
+++ b/docs/idd/project-template.md
@@ -19,9 +19,10 @@
 2. Create a capability stub with personas, journeys, and stories.
 3. Model domain concepts, rules, and lifecycles.
 4. Convert story acceptance criteria into BDD features + boundary contracts, then finalize the capability scope with models, features, and contracts.
-5. Implement code from contracts and feature expectations.
-6. Produce executable verification: unit, contract, e2e, regression.
-7. Publish evidence under `certification/` before merge (`/certification`).
+5. If work is delegated or parallelized, define role contracts before edits begin.
+6. Implement code from contracts and feature expectations.
+7. Produce executable verification: unit, contract, e2e, regression.
+8. Publish evidence under `certification/` before merge (`/certification`).
 
 ## Done criteria
 
@@ -31,3 +32,4 @@
 - No feature is accepted on manual confidence alone.
 - Certification evidence manifest is committed with traceability verified.
 - Gaps are declared honestly, not hidden.
+- Delegated roles preserve declared boundaries and invariants.

--- a/docs/idd/self-evolving-ecosystem.md
+++ b/docs/idd/self-evolving-ecosystem.md
@@ -1,0 +1,137 @@
+# Self-Evolving Engineering Ecosystem
+
+This note describes how Intention-Driven Design can act as the control plane for
+a persistent, self-improving engineering environment.
+
+IDD remains the methodology. The runtime and adaptive layers are optional
+operating environment choices that help agents execute the methodology at
+scale.
+
+## Three-layer model
+
+### 1. Seed structure
+
+IDD is the seed structure. It defines the artifact grammar that turns human
+intent into executable work:
+
+```
+Intent → Journey → Story → Feature → Contract → Verification → Certification
+```
+
+This layer provides:
+
+- traceability from goals to implementation
+- structured decomposition of work
+- verifiable outcomes
+
+Without this layer, agents optimize locally and drift.
+
+### 2. Runtime nervous system
+
+A persistent runtime coordinates agents, tools, and workflows over time.
+
+This runtime is responsible for:
+
+- agent supervision
+- task orchestration
+- workflow execution
+- tool integration
+- state persistence
+- event logging
+
+BEAM is one plausible fit because it offers lightweight concurrency,
+supervision trees, message-driven coordination, and fault tolerance. It is an
+implementation option, not an IDD requirement.
+
+### 3. Adaptive substrate
+
+A world model or similar learned system provides adaptive understanding of the
+environment:
+
+- system behavior
+- tool capabilities
+- workflow outcomes
+- error patterns
+- emergent system properties
+
+This layer helps agents:
+
+- predict outcomes
+- detect anomalies
+- compare strategies
+- improve tools and workflows
+
+It does not replace explicit engineering artifacts. It augments them.
+
+## Self-improvement loop
+
+The ecosystem improves through a closed loop:
+
+```text
+intent
+↓
+artifact formation
+↓
+agent execution
+↓
+environmental feedback
+↓
+verification
+↓
+learning and adaptation
+↓
+improved tooling and workflows
+↓
+stronger manifestation of intent
+```
+
+Each stage must remain legible to the IDD artifact spine.
+
+## Role of agent contracts
+
+Agent roles make the loop governable.
+
+Each active role should declare:
+
+- owned boundary
+- required inputs
+- decisions it may make autonomously
+- outputs it must produce
+- invariants it must preserve
+- handoff target
+- success evidence
+
+See [Agent Role](agent-role.md) and the reusable template at
+[docs/idd/templates/agent-role-contract.yaml](templates/agent-role-contract.yaml).
+
+## Governance guardrails
+
+Self-evolving systems need stable constraints:
+
+1. Intent clarity
+   Every change must trace to explicit intent artifacts.
+2. Verification rigor
+   Changes must pass structured verification, not narrative confidence.
+3. Human oversight
+   Humans approve major structural, methodological, or governance changes.
+
+These guardrails prevent:
+
+- uncontrolled optimization
+- architectural drift
+- loss of coherence
+
+## What belongs in this repo now
+
+Within this methodology repository, the practical next steps are:
+
+1. Define agent roles as reusable contracts.
+2. Extend workflow skills to require role contracts for delegated work.
+3. Teach PR review to flag cross-boundary drift.
+4. Define improvement proposals as first-class artifacts before automating them.
+
+## What does not belong here yet
+
+This repository should not hard-code a specific persistent runtime, agent
+framework, or world model implementation. Those belong in downstream systems or
+reference implementations once the methodology contracts are stable.

--- a/docs/idd/templates/agent-role-contract.yaml
+++ b/docs/idd/templates/agent-role-contract.yaml
@@ -1,0 +1,31 @@
+# Minimal role contract template for orchestrated IDD work.
+role: implementation-role
+mission: Change implementation to satisfy declared contracts and tests.
+owns:
+  - frontend/src/
+  - backend/src/
+inputs:
+  - specs/stories/
+  - specs/features/
+  - specs/contracts/openapi/
+must_preserve:
+  - traceability chain
+  - capability scope
+  - declared model invariants
+may_change:
+  - implementation files
+  - test files in owned boundary
+must_not_change:
+  - persona intent without narrative update
+  - contract semantics without behavior-contract update
+handoff_to:
+  - validation-role
+success_evidence:
+  - changed files trace to upstream artifacts
+  - verification passes for owned boundary
+human_approval_required_for:
+  - changes to methodology contracts
+  - changes to governance rules
+notes: >
+  Copy this template and tighten write scope, invariants, and approval rules for
+  each active role.

--- a/docs/idd/templates/methodology-improvement-proposal.md
+++ b/docs/idd/templates/methodology-improvement-proposal.md
@@ -1,0 +1,51 @@
+# Methodology Improvement Proposal
+
+## Summary
+
+- Title:
+- Status: exploratory | provisional | canonical-candidate
+- Owner:
+- Date:
+
+## Intent
+
+- What problem in the methodology are we addressing?
+- What decision or outcome should this improve?
+- Why is the current approach insufficient?
+
+## Scope
+
+- Affected docs:
+- Affected skills:
+- Affected tools or CI:
+- Governance impact:
+
+## Proposed change
+
+- What is the new practice, rule, or artifact?
+- What remains unchanged?
+- Why is this the smallest useful change?
+
+## Evaluation plan
+
+- Harness or environment:
+- Scenarios to test:
+- Failure modes to watch:
+- Signals or metrics:
+
+## Worked example
+
+- What concrete example was run?
+- What happened?
+- What did we learn?
+
+## Evidence
+
+- What evidence supports this proposal?
+- Is the evidence strong enough for exploratory, provisional, or canonical use?
+
+## Promotion decision
+
+- Recommended state after this PR:
+- Human approval required:
+- Follow-up needed before promotion:

--- a/skills/idd-workflow/SKILL.md
+++ b/skills/idd-workflow/SKILL.md
@@ -234,17 +234,23 @@ Discovery answers "what skills are available." Selection answers "which one shou
    ├── Ask only if multiple plausible matches remain
    └── Output: selected stack-specific skills + fallback assumptions
 
-6. Implementation (parallel, stack-specific)
+6. Define agent roles when using delegated or parallel execution
+   ├── Assign each role an owned boundary and allowed write scope
+   ├── Declare required upstream artifacts and preserved invariants
+   ├── Define expected outputs and handoff target
+   └── Route cross-boundary ambiguity back to the relevant upstream skill
+
+7. Implementation (parallel, stack-specific)
    ├── Selected backend skill → backend/
    ├── Selected frontend skill → frontend/
    └── If no dedicated skill exists, follow repo architecture docs + generic implementation checklist
 
-7. /e2e-journey-testing
+8. /e2e-journey-testing
    ├── Create journey map
    ├── Implement Playwright tests
    └── Output: specs/journey-maps/, frontend/e2e/
 
-8. /certification
+9. /certification
    ├── Verify capability scope is complete
    ├── Collect test evidence
    ├── Generate evidence manifest (references capability file)
@@ -279,6 +285,7 @@ Discovery answers "what skills are available." Selection answers "which one shou
 4. Implement changes:
    - Backend → Selected backend technical skill or generic backend checklist
    - Frontend → Selected frontend technical skill or generic frontend checklist
+   - Delegated work → define role contracts before parallel edits
 
 5. Update tests:
    - Journey affected? → /e2e-journey-testing
@@ -327,6 +334,9 @@ Bug fixes follow the Fix Forward principle (C13): fix the spec first, then the c
 
 **Never fix code without updating the spec.** Fixing code without updating specs is drift — the single most common way systems lose alignment with their intent.
 Always apply repo overlay constraints while fixing forward (for example, architecture boundaries and test pyramid policy).
+
+If multiple actors are involved in the repair, assign explicit role contracts so
+each fix-forward step has a bounded owner.
 
 ### Fix Forward Skill Routing
 
@@ -433,6 +443,8 @@ solution-narrative              ← Stack-agnostic
         ▼
  behavior-contract              ← Stack-agnostic
         │
+        ├────────── define role contracts when delegating
+        │
         ├──────────────────────┐
         ▼                      ▼
   backend-skill          frontend-skill     ← Stack-specific
@@ -452,6 +464,7 @@ solution-narrative              ← Stack-agnostic
 
 - **IDD philosophy**: `docs/idd/manifesto.md`
 - **Concept definitions**: `docs/idd/concepts.md`
+- **Agent role extension**: `docs/idd/agent-role.md`
 - **Front-matter schema**: `docs/idd/front-matter-spec.md`
 - **Certification standards**: `docs/idd/certification-guide.md`
 - **PR compliance checks**: `skills/pr-review/SKILL.md`
@@ -470,6 +483,7 @@ When this meta-skill is used by an orchestrator, include these fields in the han
 - `repo_overlay_constraints` (summary bullets when loaded, otherwise the fallback assumptions or open gaps)
 - `technical_skills_discovered` (list of repo-local candidates with area/framework hints)
 - `technical_skill_selection` (chosen skill per area with selection source and evidence)
+- `agent_roles` (role contracts with owner, scope, invariants, outputs, and handoff target)
 - `skills_selected` (ordered list for this task)
 - `blocking_issues` (true blockers only; missing overlay alone does not belong here)
 

--- a/skills/pr-review/SKILL.md
+++ b/skills/pr-review/SKILL.md
@@ -20,6 +20,8 @@ Two execution modes:
 2. **Agent-assisted** — Claude (or another agent) loads this skill for semantic review.
 
 The automated layer is fast and cheap (no LLM). The agent layer catches what static checks cannot: misaligned intent, incomplete journeys, naming drift.
+When role contracts are present, it should also catch cross-boundary changes
+that violate the declared execution contract.
 
 ## When to Use
 
@@ -58,6 +60,7 @@ The automated layer is fast and cheap (no LLM). The agent layer catches what sta
 │  │  • Completeness (missing edge-case scenarios,     │  │
 │  │    missing error responses)                       │  │
 │  │  • Model drift (code diverging from model rules)  │  │
+│  │  • Role-boundary drift in delegated work          │  │
 │  └───────────────────────────────────────────────────┘  │
 │                          │                              │
 │                  comment on PR                          │
@@ -135,6 +138,36 @@ If the PR modifies implementation files (`backend/src/`, `frontend/src/`) but no
 
 **Pass criteria**: Warning only (never blocks).
 
+### Check 6: Role Contract Coverage
+
+If the PR includes delegated or multi-agent work and role contracts are present,
+verify that:
+
+- each changed file falls within at least one declared role boundary
+- methodology or governance docs changed by an implementation role are flagged
+- artifact changes outside a role's allowed scope are reported for review
+
+This check is advisory by default because repositories may adopt role contracts
+incrementally.
+
+**Pass criteria**: Warning only unless the repo explicitly makes role contracts mandatory.
+
+### Check 7: Methodology Change Coverage
+
+If the PR changes methodology-defining surfaces such as `docs/idd/`, `skills/`,
+`tools/`, or `.github/workflows/`, verify that the PR includes enough context to
+justify the change:
+
+- an intent artifact or design note describing the change
+- clear statement of the affected methodology boundary
+- evidence or worked example supporting the proposed adoption state
+- explicit indication of whether the change is exploratory, provisional, or canonical
+
+This check is advisory by default. It exists to ensure changes to the
+methodology follow the methodology.
+
+**Pass criteria**: Warning only unless the repo chooses to make methodology artifacts mandatory.
+
 ## Layer 2: Semantic Review
 
 Optional LLM-assisted pass that covers what deterministic checks cannot:
@@ -145,6 +178,28 @@ Optional LLM-assisted pass that covers what deterministic checks cannot:
 - **Completeness** — features cover happy-path, validation, authorization, and contract-defined error responses.
 
 Output: PR comments. Never blocks merge on Layer 2 alone.
+
+### Semantic Check: Role-Boundary Drift
+
+When role contracts are available:
+
+- compare the changed files to the active role boundaries
+- flag actors changing artifacts outside their declared ownership
+- flag downstream edits that should have been routed through an upstream skill
+- flag methodology or governance changes that lack explicit human approval
+
+**Output**: PR comment summarizing role-boundary drift risks.
+
+### Semantic Check: Methodology Change Legibility
+
+When the PR changes methodology-defining files:
+
+- identify whether the change declares intent clearly
+- identify whether the scope of the change is explicit
+- identify whether evidence matches the claimed promotion state
+- flag experiments that are being written as canonical doctrine too early
+
+**Output**: PR comment summarizing whether the methodology change is legible, scoped, and evidenced.
 
 ## GitHub Action Integration
 
@@ -232,6 +287,7 @@ PR review catches problems early and cheaply. Certification provides the formal 
 | C14 — Agent Non-Negotiables | **primary**: enforces rule 3 (no merge without evidence) at PR boundary |
 | C12 — Done Means Verified | referenced: PR review is the first verification gate |
 | C15 — Capability as Cert Unit | referenced: capability scope check uses capability artifacts |
+| C16 — Agent Role as Execution Contract | referenced: role-boundary drift checks delegated work |
 
 ## Guardrails
 
@@ -240,4 +296,5 @@ PR review catches problems early and cheaply. Certification provides the formal 
 - Never block a PR on Layer 2 results alone. Humans decide on semantic issues.
 - The spec-before-code check is a warning, never a blocker. Pure refactors are valid.
 - PR review does not replace certification. It complements it.
+- Methodology-change checks are warnings unless the repo explicitly promotes them to blockers.
 - Check scripts must exit 0 (pass) or 1 (fail) — no partial states.


### PR DESCRIPTION
## Summary

- Introduces **agent role** as an IDD extension for orchestrated agency: a bounded execution contract covering responsibility, inputs, allowed decisions, outputs, and handoff. Lives at `docs/idd/agent-role.md` with a reusable template under `docs/idd/templates/agent-role-contract.yaml`.
- Introduces a **methodology change process** (`docs/idd/methodology-change-process.md`) with explicit exploratory → provisional → canonical states, and a matching improvement-proposal template. Applies IDD to changes in IDD itself.
- Integrates both into `skills/idd-workflow/SKILL.md` (role contracts as a delegated-work step, role outputs in handoff) and `skills/pr-review/SKILL.md` (role-boundary drift check, methodology-change coverage check).
- Adds `docs/idd/self-evolving-ecosystem.md` — the three-layer model (seed structure / runtime / adaptive substrate) that frames where role contracts fit.

## Why now

Extracted from the long-running `explore/methodology-attribution` branch. These two strands are coherent and ready to land independently of the broader attribution exploration (P1–P6 candidate primitives), which remains on its own exploration branch. The change-process vocabulary (exploratory / provisional / canonical) will also seed the conformance tiers in the upcoming schema work under #24 (specifically #37).

## Test plan

- [ ] `docs/idd/agent-role.md` reads coherently against existing `concepts.md` and `concept-skill-map.md`.
- [ ] `methodology-change-process.md` integrates cleanly with PR review guidance.
- [ ] No spec/contract files changed; no validator behavior change expected.
- [ ] Skill changes are additive — existing workflows continue to work without role contracts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)