### PR TITLE
Publish IDD schemas as machine-readable artifacts (#36)

### DIFF
--- a/SCHEMA.md
+++ b/SCHEMA.md
@@ -1,0 +1,138 @@
+# IDD Schemas
+
+The Intention-Driven Design specification format is published as a set of
+machine-readable JSON Schemas under [`schemas/v1/`](schemas/v1/). Every
+validator, certification check, documentation generator, IDE plugin, and AI
+assistant that touches an IDD artifact should derive its understanding of the
+format from these schemas.
+
+The registry is [`schemas/v1/index.json`](schemas/v1/index.json). Each schema
+declares a stable `$id` URL under
+`https://github.com/slusset/intention-driven-design/schemas/v1/`.
+
+## Dialect
+
+All schemas use **JSON Schema Draft 2020-12**
+(`https://json-schema.org/draft/2020-12/schema`).
+
+## Artifact set (v1)
+
+| Artifact | Kind | Schema | Applies to |
+|---|---|---|---|
+| Persona | front-matter | [`persona.schema.json`](schemas/v1/persona.schema.json) | `specs/personas/**/*.md` |
+| Journey | front-matter | [`journey.schema.json`](schemas/v1/journey.schema.json) | `specs/journeys/**/*.md` |
+| Story | front-matter | [`story.schema.json`](schemas/v1/story.schema.json) | `specs/stories/**/*.md` |
+| Feature | front-matter | [`feature.schema.json`](schemas/v1/feature.schema.json) | `specs/features/**/*.feature` |
+| Model | document | [`model.schema.json`](schemas/v1/model.schema.json) | `specs/models/**/*.model.yaml` |
+| Lifecycle | document | [`lifecycle.schema.json`](schemas/v1/lifecycle.schema.json) | `specs/models/**/*.lifecycle.yaml` |
+| Journey Map | document | [`journey-map.schema.json`](schemas/v1/journey-map.schema.json) | `specs/journey-maps/**/*.{journey-map,map}.yaml` |
+| Capability | document | [`capability.schema.json`](schemas/v1/capability.schema.json) | `specs/capabilities/**/*.capability.yaml` |
+| Fixture | document | [`fixture.schema.json`](schemas/v1/fixture.schema.json) | `specs/fixtures/**/*.{fixture.yaml,json}` |
+
+**Front-matter** schemas describe the YAML or comment header of a Markdown,
+Gherkin, or JSON artifact. The body of these files is freeform narrative or
+parsed by a separate grammar (Gherkin parser, JSON parser).
+
+**Document** schemas describe the entire parsed YAML or JSON document.
+
+## What the schemas cover
+
+The schemas express **per-document grammar**: types, required fields, enum
+membership, nested structure, and reference relationships within a single
+document. Validators consume the schema via
+[`tools/lib/schema-loader.js`](tools/lib/schema-loader.js) and run it against
+parsed artifact content before applying any remaining imperative checks.
+
+## What the schemas do not cover
+
+Constraints that span more than one document live in imperative checkers, not
+in JSON Schema:
+
+| Constraint | Checker | Notes |
+|---|---|---|
+| Traceability — every referenced file exists | `tools/validate-traceability.js` | Filesystem resolution |
+| Capability scope coverage | `tools/validate-capability-scope.js` | Cross-file accounting |
+| Fixture payload ↔ contract operation | `tools/validate-fixtures.js` (delegates to OpenAPI/AsyncAPI/JSON-RPC) | Multi-file payload validation |
+| Evidence manifest references real outputs | `tools/validate-evidence.js` | Filesystem resolution |
+
+Two future initiatives extend the cross-document layer:
+
+- **#40 — reference closure as a capability-scope obligation.** A capability's
+  declared scope is checked against the transitive closure of artifacts
+  reachable from its journeys, stories, features, models, and contracts.
+- **#41 — enforced rules bound to concrete enforcement points.** Each model
+  rule with `enforced:` resolves to a real DB constraint, OpenAPI schema
+  fragment, named invariant, or test scenario.
+
+## Version policy
+
+The schema set is versioned with semantic versioning:
+
+- **Patch** — non-substantive changes (descriptions, examples, comments).
+- **Minor** — additive changes: new fields, new optional artifact kinds, new
+  variants. Existing valid documents remain valid.
+- **Major** — breaking changes: removed fields, tightened constraints that
+  invalidate previously valid documents, removed artifact kinds. Major bumps
+  ship with a documented migration path.
+
+The current version is **`1.0.0`** (declared in
+[`schemas/v1/index.json`](schemas/v1/index.json)).
+
+When the major version increments, the new schemas are published under a new
+directory (`schemas/v2/`) and the previous directory is retained for backward
+compatibility for at least one minor release of `idd-toolkit`.
+
+## Extension model
+
+Today schemas allow unknown keys by default. **Issue #37** introduces
+closed-world key validation with a `$conformance` marker that tags each field
+as `canonical`, `legacy-compatible`, or `experimental`. Until #37 lands,
+extensions are silently accepted; once it lands, every key must be enumerated
+in the schema and tagged with a conformance tier.
+
+The change-process states for the schemas mirror the methodology-change-process
+states in [`docs/idd/methodology-change-process.md`](docs/idd/methodology-change-process.md):
+
+| Schema tier | Methodology state | Meaning |
+|---|---|---|
+| `canonical` | canonical | Load-bearing. Downstream tools depend on this. |
+| `legacy-compatible` | provisional | Retained for back-compat. Scheduled for retirement. |
+| `experimental` | exploratory | Proposed extension. Warnings rather than errors. |
+
+## Conformance fixtures
+
+The artifacts under [`specs/`](specs/) double as the schema test suite. Every
+file in `specs/` must validate against its corresponding schema. The test that
+enforces this is
+[`tests/schemas/conformance.test.js`](tests/schemas/conformance.test.js); it
+runs as part of `npm test`.
+
+When you add a new spec example, no additional registration is required —
+the test discovers it via the directory layout and looks up the right schema
+in the registry.
+
+## Adding a new artifact kind
+
+1. Draft the schema under `schemas/v1/<kind>.schema.json` with a stable `$id`.
+2. Add a registry entry under `schemas/v1/index.json#/artifacts/<kind>`.
+3. Add a conformance fixture under `specs/<plural>/` and confirm
+   `npm test` passes.
+4. If the artifact has a validator, load its schema via
+   `getValidator('<kind>')` in `tools/lib/schema-loader.js`.
+5. Bump the minor version in `schemas/v1/index.json#/version`.
+
+## Consuming the schemas externally
+
+Downstream tools resolve schemas by `$id`. Two convenient access patterns:
+
+- **HTTP fetch** — `curl https://raw.githubusercontent.com/slusset/intention-driven-design/main/schemas/v1/<kind>.schema.json`
+- **npm install** — `npm install idd-toolkit` ships the `schemas/` directory in
+  its `files:` manifest entry. Schemas can be loaded from
+  `node_modules/idd-toolkit/schemas/v1/`.
+
+IDE integration: editors with `yaml-language-server` support can attach a
+schema to a file via a comment at the top of the YAML file:
+
+```yaml
+# yaml-language-server: $schema=https://raw.githubusercontent.com/slusset/intention-driven-design/main/schemas/v1/model.schema.json
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "ajv": "^8.18.0",
+        "ajv": "^8.20.0",
         "ajv-formats": "^3.0.1",
         "js-yaml": "^4.1.0"
       },
@@ -833,11 +833,10 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -2515,7 +2514,6 @@
       "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -3012,7 +3010,6 @@
       "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },

--- a/package.json
+++ b/package.json
@@ -35,12 +35,14 @@
     "tools/validate-*.js",
     "tools/generate-evidence.js",
     "tools/graph-generation/",
+    "schemas/",
     "skills/",
     "technical-skills/",
-    "docs/"
+    "docs/",
+    "SCHEMA.md"
   ],
   "dependencies": {
-    "ajv": "^8.18.0",
+    "ajv": "^8.20.0",
     "ajv-formats": "^3.0.1",
     "js-yaml": "^4.1.0"
   },

--- a/schemas/v1/capability.schema.json
+++ b/schemas/v1/capability.schema.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/slusset/intention-driven-design/schemas/v1/capability.schema.json",
+  "title": "IDD Capability",
+  "description": "Schema for IDD capability documents (.capability.yaml). Declares the artifact set in scope for a capability. Issue #40 adds reference-closure validation on top of this shape; this schema only describes the document.",
+  "type": "object",
+  "required": ["id", "type", "scope"],
+  "properties": {
+    "id": { "type": "string", "minLength": 1 },
+    "type": { "const": "capability" },
+    "description": { "type": "string" },
+    "scope": {
+      "type": "object",
+      "minProperties": 1,
+      "properties": {
+        "personas": { "$ref": "#/$defs/refList" },
+        "journeys": { "$ref": "#/$defs/refList" },
+        "stories": { "$ref": "#/$defs/refList" },
+        "features": { "$ref": "#/$defs/refList" },
+        "models": { "$ref": "#/$defs/refList" },
+        "contracts": { "$ref": "#/$defs/refList" },
+        "fixtures": { "$ref": "#/$defs/refList" },
+        "journey_maps": { "$ref": "#/$defs/refList" }
+      },
+      "additionalProperties": { "$ref": "#/$defs/refList" }
+    }
+  },
+  "$defs": {
+    "refList": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    }
+  }
+}

--- a/schemas/v1/feature.schema.json
+++ b/schemas/v1/feature.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/slusset/intention-driven-design/schemas/v1/feature.schema.json",
+  "title": "IDD Feature front-matter",
+  "description": "Schema for the parsed Gherkin '# key: value' header block of an IDD feature file. The Gherkin body itself is validated by Gherkin parsers, not this schema.",
+  "type": "object",
+  "required": ["id", "type"],
+  "properties": {
+    "id": { "type": "string", "minLength": 1 },
+    "type": { "const": "feature" },
+    "story": { "type": "string" },
+    "journey": { "type": "string" },
+    "scenario": { "type": "string" }
+  }
+}

--- a/schemas/v1/fixture.schema.json
+++ b/schemas/v1/fixture.schema.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/slusset/intention-driven-design/schemas/v1/fixture.schema.json",
+  "title": "IDD Fixture",
+  "description": "Schema for IDD fixture documents (.fixture.yaml or .json). YAML fixtures carry id/type at the top level. JSON fixtures carry the same metadata under a `_meta` block. Fixtures describe canonical request/response pairs (HTTP, RPC, or event) referenced from features and journey maps. The body shape beyond the metadata is intentionally open in v1 — payload schemas come from the contract layer (OpenAPI / AsyncAPI / JSON-RPC) via fixture validation.",
+  "type": "object",
+  "anyOf": [
+    { "$ref": "#/$defs/topLevelMetadata" },
+    { "$ref": "#/$defs/nestedMetadata" }
+  ],
+  "properties": {
+    "id": { "type": "string", "minLength": 1 },
+    "type": { "const": "fixture" },
+    "story": { "type": "string" },
+    "feature": { "type": "string" },
+    "scenario": { "type": "string" },
+    "contract": { "$ref": "#/$defs/contractRef" },
+    "request": { "type": ["object", "array"] },
+    "response": { "type": ["object", "array"] },
+    "event": { "type": ["object", "array"] },
+    "rpc": { "type": ["object", "array"] },
+    "_meta": {
+      "type": "object",
+      "description": "Used in JSON fixtures to carry the same metadata fields under a single key.",
+      "required": ["id", "type"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "type": { "const": "fixture" },
+        "story": { "type": "string" },
+        "feature": { "type": "string" },
+        "scenario": { "type": "string" },
+        "contract": { "$ref": "#/$defs/contractRef" },
+        "schema": { "type": "string" }
+      }
+    }
+  },
+  "$defs": {
+    "topLevelMetadata": {
+      "type": "object",
+      "required": ["id", "type"]
+    },
+    "nestedMetadata": {
+      "type": "object",
+      "required": ["_meta"]
+    },
+    "contractRef": {
+      "description": "Either a path to the contract file (string) or a structured contract reference (protocol, ref, operation/channel/method).",
+      "oneOf": [
+        { "type": "string" },
+        {
+          "type": "object",
+          "properties": {
+            "protocol": { "type": "string" },
+            "ref": { "type": "string" },
+            "operation": { "type": "string" },
+            "channel": { "type": "string" },
+            "action": { "type": "string" },
+            "method": { "type": "string" }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/schemas/v1/index.json
+++ b/schemas/v1/index.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/slusset/intention-driven-design/schemas/v1/index.json",
+  "title": "IDD Schema Registry (v1)",
+  "description": "Registry of IDD schemas at v1. Each entry maps an artifact kind to its canonical $id and to the local path under schemas/v1/. Consumers should prefer the $id URL; local validators resolve via the path.",
+  "version": "1.0.0",
+  "dialect": "https://json-schema.org/draft/2020-12/schema",
+  "artifacts": {
+    "persona": {
+      "kind": "front-matter",
+      "applies_to": "specs/personas/**/*.md",
+      "$id": "https://github.com/slusset/intention-driven-design/schemas/v1/persona.schema.json",
+      "path": "persona.schema.json"
+    },
+    "journey": {
+      "kind": "front-matter",
+      "applies_to": "specs/journeys/**/*.md",
+      "$id": "https://github.com/slusset/intention-driven-design/schemas/v1/journey.schema.json",
+      "path": "journey.schema.json"
+    },
+    "story": {
+      "kind": "front-matter",
+      "applies_to": "specs/stories/**/*.md",
+      "$id": "https://github.com/slusset/intention-driven-design/schemas/v1/story.schema.json",
+      "path": "story.schema.json"
+    },
+    "feature": {
+      "kind": "front-matter",
+      "applies_to": "specs/features/**/*.feature",
+      "$id": "https://github.com/slusset/intention-driven-design/schemas/v1/feature.schema.json",
+      "path": "feature.schema.json"
+    },
+    "model": {
+      "kind": "document",
+      "applies_to": "specs/models/**/*.model.yaml",
+      "$id": "https://github.com/slusset/intention-driven-design/schemas/v1/model.schema.json",
+      "path": "model.schema.json"
+    },
+    "lifecycle": {
+      "kind": "document",
+      "applies_to": "specs/models/**/*.lifecycle.yaml",
+      "$id": "https://github.com/slusset/intention-driven-design/schemas/v1/lifecycle.schema.json",
+      "path": "lifecycle.schema.json"
+    },
+    "journey-map": {
+      "kind": "document",
+      "applies_to": "specs/journey-maps/**/*.{journey-map,map}.yaml",
+      "$id": "https://github.com/slusset/intention-driven-design/schemas/v1/journey-map.schema.json",
+      "path": "journey-map.schema.json"
+    },
+    "capability": {
+      "kind": "document",
+      "applies_to": "specs/capabilities/**/*.capability.yaml",
+      "$id": "https://github.com/slusset/intention-driven-design/schemas/v1/capability.schema.json",
+      "path": "capability.schema.json"
+    },
+    "fixture": {
+      "kind": "document",
+      "applies_to": "specs/fixtures/**/*.{fixture.yaml,json}",
+      "$id": "https://github.com/slusset/intention-driven-design/schemas/v1/fixture.schema.json",
+      "path": "fixture.schema.json"
+    }
+  },
+  "cross_document_constraints": {
+    "description": "Constraints that JSON Schema cannot express. Validated by imperative checkers, not by these schemas.",
+    "constraints": [
+      "traceability: every refs/sources/scope/journey/story/feature reference resolves to an existing file (tools/validate-traceability.js)",
+      "capability-scope: every artifact listed under a capability's scope exists (tools/validate-capability-scope.js)",
+      "fixture-contract: fixture payloads validate against their declared contract operation (tools/validate-fixtures.js)",
+      "evidence: certification manifests reference real test outputs (tools/validate-evidence.js)"
+    ],
+    "future": [
+      "issue #40: reference-closure as a capability-scope obligation",
+      "issue #41: model 'enforced:' rules resolve to concrete enforcement points"
+    ]
+  }
+}

--- a/schemas/v1/journey-map.schema.json
+++ b/schemas/v1/journey-map.schema.json
@@ -1,0 +1,84 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/slusset/intention-driven-design/schemas/v1/journey-map.schema.json",
+  "title": "IDD Journey Map",
+  "description": "Schema for IDD journey map documents (.journey-map.yaml / .map.yaml). Two step models are supported: the current array form (preferred) and the legacy keyed-object form. The 'non-sequential journey_step' rule and the assertion/action vocabularies are validator behaviors today; issues #38 and #39 replace them with kinded grammars and a declarative shape selector.",
+  "type": "object",
+  "required": ["id", "type", "journey"],
+  "properties": {
+    "id": { "type": "string", "minLength": 1 },
+    "type": { "const": "journey-map" },
+    "journey": { "type": "string", "minLength": 1 },
+    "sources": {
+      "type": "object",
+      "properties": {
+        "journey": { "type": "string" },
+        "stories": { "type": "array", "items": { "type": "string" } },
+        "features": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "fixtures": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "properties": { "ref": { "type": "string" } }
+      }
+    },
+    "steps": {
+      "oneOf": [
+        { "$ref": "#/$defs/stepArray" },
+        { "$ref": "#/$defs/stepObject" }
+      ]
+    }
+  },
+  "$defs": {
+    "stepArray": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["id"],
+        "properties": {
+          "id": { "type": "string", "pattern": "^[a-z][a-z0-9-]*$" },
+          "story": { "type": "string" },
+          "title": { "type": "string" },
+          "journey_step": { "type": ["integer", "string"] },
+          "actions": { "type": "array", "items": { "$ref": "#/$defs/action" } },
+          "assertions": { "type": "array", "items": { "$ref": "#/$defs/assertion" } }
+        }
+      }
+    },
+    "stepObject": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "required": ["journey_step", "title"],
+        "properties": {
+          "journey_step": { "type": "integer", "minimum": 1 },
+          "title": { "type": "string" },
+          "story": { "type": "string" },
+          "actions": { "type": "array", "items": { "$ref": "#/$defs/action" } },
+          "assertions": { "type": "array", "items": { "$ref": "#/$defs/assertion" } }
+        }
+      }
+    },
+    "action": {
+      "type": "object",
+      "required": ["type"],
+      "properties": {
+        "type": { "type": "string" },
+        "target": { "type": ["string", "object"] },
+        "value": {}
+      }
+    },
+    "assertion": {
+      "type": "object",
+      "required": ["type"],
+      "properties": {
+        "type": { "type": "string" },
+        "selector": { "type": ["string", "object"] },
+        "expected": {}
+      }
+    }
+  }
+}

--- a/schemas/v1/journey.schema.json
+++ b/schemas/v1/journey.schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/slusset/intention-driven-design/schemas/v1/journey.schema.json",
+  "title": "IDD Journey front-matter",
+  "description": "Schema for the YAML front-matter of an IDD journey artifact (Markdown body is freeform).",
+  "type": "object",
+  "required": [
+    "id",
+    "type"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "type": {
+      "const": "journey"
+    },
+    "refs": {
+      "type": "object",
+      "properties": {
+        "persona": {}
+      },
+      "additionalProperties": true
+    }
+  }
+}

--- a/schemas/v1/lifecycle.schema.json
+++ b/schemas/v1/lifecycle.schema.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/slusset/intention-driven-design/schemas/v1/lifecycle.schema.json",
+  "title": "IDD Lifecycle",
+  "description": "Schema for IDD lifecycle documents (.lifecycle.yaml). A lifecycle declares states and transitions for an entity. The 'at least one terminal state' rule is enforced today; issue #39 replaces it with a declarative shape selector.",
+  "type": "object",
+  "required": ["id", "type", "entity", "initial_state", "states"],
+  "properties": {
+    "id": { "type": "string", "minLength": 1 },
+    "type": { "const": "model" },
+    "entity": { "type": "string", "minLength": 1 },
+    "description": { "type": "string" },
+    "sources": { "$ref": "https://github.com/slusset/intention-driven-design/schemas/v1/model.schema.json#/$defs/sources" },
+    "initial_state": { "type": "string", "minLength": 1 },
+    "states": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": { "$ref": "#/$defs/state" }
+    },
+    "transitions": {
+      "type": "object",
+      "additionalProperties": { "$ref": "#/$defs/transition" }
+    }
+  },
+  "$defs": {
+    "state": {
+      "type": "object",
+      "properties": {
+        "description": { "type": "string" },
+        "terminal": { "type": "boolean" }
+      }
+    },
+    "stateRef": {
+      "oneOf": [
+        { "type": "string" },
+        { "type": "array", "items": { "type": "string" }, "minItems": 1 }
+      ]
+    },
+    "transition": {
+      "type": "object",
+      "required": ["from", "to"],
+      "properties": {
+        "from": { "$ref": "#/$defs/stateRef" },
+        "to": { "$ref": "#/$defs/stateRef" },
+        "trigger": { "type": "string" },
+        "description": { "type": "string" }
+      }
+    }
+  }
+}

--- a/schemas/v1/model.schema.json
+++ b/schemas/v1/model.schema.json
@@ -1,0 +1,175 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/slusset/intention-driven-design/schemas/v1/model.schema.json",
+  "title": "IDD Domain Model",
+  "description": "Schema for IDD domain model documents (.model.yaml). A model is one of: entity, value-object, aggregate, catalog, or a shared value-objects bundle. The discriminating top-level key selects the variant.",
+  "type": "object",
+  "required": ["id", "type"],
+  "properties": {
+    "id": { "type": "string", "minLength": 1 },
+    "type": { "const": "model" },
+    "description": { "type": "string" },
+    "sources": { "$ref": "#/$defs/sources" },
+    "rules": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/rule" }
+    }
+  },
+  "anyOf": [
+    { "$ref": "#/$defs/entityVariant" },
+    { "$ref": "#/$defs/valueObjectVariant" },
+    { "$ref": "#/$defs/aggregateVariant" },
+    { "$ref": "#/$defs/catalogVariant" },
+    { "$ref": "#/$defs/bundleVariant" }
+  ],
+  "$defs": {
+    "sources": {
+      "type": "object",
+      "properties": {
+        "stories": { "type": "array", "items": { "type": "string" } },
+        "journeys": { "type": "array", "items": { "type": "string" } },
+        "features": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "attributeType": {
+      "description": "Canonical attribute primitive types. Closed-world enforcement of this set is deferred to issue #37.",
+      "type": "string"
+    },
+    "attribute": {
+      "type": "object",
+      "required": ["type"],
+      "properties": {
+        "type": { "$ref": "#/$defs/attributeType" },
+        "required": { "type": "boolean" },
+        "constraints": { "type": "array", "items": { "type": ["string", "object"] } },
+        "values": { "type": "array" },
+        "description": { "type": "string" }
+      }
+    },
+    "attributeBlock": {
+      "type": "object",
+      "additionalProperties": { "$ref": "#/$defs/attribute" }
+    },
+    "relationship": {
+      "type": "object",
+      "required": ["type", "entity"],
+      "properties": {
+        "type": {
+          "description": "Relationship kind. Replaced by a richer kinded grammar in issue #38.",
+          "type": "string"
+        },
+        "entity": { "type": "string" },
+        "description": { "type": "string" }
+      }
+    },
+    "rule": {
+      "type": "object",
+      "properties": {
+        "id": { "type": "string" },
+        "description": { "type": "string" },
+        "when": { "type": "string" },
+        "then": { "type": "string" },
+        "enforced": {
+          "description": "Today this is a narrative tag. Bound to concrete enforcement points in issue #41.",
+          "type": ["string", "array", "object"]
+        }
+      }
+    },
+    "entityVariant": {
+      "type": "object",
+      "required": ["entity"],
+      "properties": {
+        "entity": { "type": "string", "minLength": 1 },
+        "aggregate": { "type": "string" },
+        "identity": {
+          "type": "object",
+          "required": ["field"],
+          "properties": {
+            "field": { "type": "string" },
+            "type": { "type": "string" }
+          }
+        },
+        "attributes": { "$ref": "#/$defs/attributeBlock" },
+        "relationships": {
+          "type": "object",
+          "additionalProperties": { "$ref": "#/$defs/relationship" }
+        }
+      }
+    },
+    "valueObjectVariant": {
+      "type": "object",
+      "required": ["value_object"],
+      "properties": {
+        "value_object": { "type": "string", "minLength": 1 },
+        "attributes": { "$ref": "#/$defs/attributeBlock" },
+        "properties": { "$ref": "#/$defs/attributeBlock" }
+      }
+    },
+    "aggregateVariant": {
+      "type": "object",
+      "required": ["aggregate"],
+      "properties": {
+        "aggregate": { "type": "string", "minLength": 1 },
+        "entities": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "entity": { "type": "string" },
+              "ref": { "type": "string" },
+              "description": { "type": "string" }
+            }
+          }
+        },
+        "value_objects": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "value_object": { "type": "string" },
+              "ref": { "type": "string" },
+              "description": { "type": "string" },
+              "attributes": { "$ref": "#/$defs/attributeBlock" },
+              "properties": { "$ref": "#/$defs/attributeBlock" }
+            }
+          }
+        }
+      }
+    },
+    "catalogVariant": {
+      "type": "object",
+      "required": ["catalog"],
+      "properties": {
+        "catalog": { "type": "string", "minLength": 1 },
+        "properties": { "$ref": "#/$defs/attributeBlock" },
+        "entries": { "type": "object" },
+        "items": { "type": "object" }
+      }
+    },
+    "bundleVariant": {
+      "description": "Shared value-objects bundle: a file that defines multiple reusable value objects without a single entity/aggregate/catalog.",
+      "type": "object",
+      "required": ["value_objects"],
+      "not": { "anyOf": [
+        { "required": ["entity"] },
+        { "required": ["aggregate"] },
+        { "required": ["catalog"] },
+        { "required": ["value_object"] }
+      ] },
+      "properties": {
+        "value_objects": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "value_object": { "type": "string" },
+              "description": { "type": "string" },
+              "attributes": { "$ref": "#/$defs/attributeBlock" },
+              "properties": { "$ref": "#/$defs/attributeBlock" }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/schemas/v1/persona.schema.json
+++ b/schemas/v1/persona.schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/slusset/intention-driven-design/schemas/v1/persona.schema.json",
+  "title": "IDD Persona front-matter",
+  "description": "Schema for the YAML front-matter of an IDD persona artifact (Markdown body is freeform).",
+  "type": "object",
+  "required": [
+    "id",
+    "type"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "type": {
+      "const": "persona"
+    },
+    "refs": {
+      "type": "object",
+      "additionalProperties": true
+    }
+  }
+}

--- a/schemas/v1/story.schema.json
+++ b/schemas/v1/story.schema.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/slusset/intention-driven-design/schemas/v1/story.schema.json",
+  "title": "IDD Story front-matter",
+  "description": "Schema for the YAML front-matter of an IDD story artifact (Markdown body is freeform).",
+  "type": "object",
+  "required": [
+    "id",
+    "type"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "type": {
+      "const": "story"
+    },
+    "refs": {
+      "type": "object",
+      "properties": {
+        "journey": {},
+        "persona": {}
+      },
+      "additionalProperties": true
+    }
+  }
+}

--- a/tests/schemas/conformance.test.js
+++ b/tests/schemas/conformance.test.js
@@ -1,0 +1,148 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const yaml = require('js-yaml');
+
+const { getValidator, formatAjvErrors, loadIndex } = require('../../tools/lib/schema-loader');
+
+const REPO_ROOT = path.join(__dirname, '..', '..');
+const SPECS_ROOT = path.join(REPO_ROOT, 'specs');
+
+function findFiles(dir, pattern) {
+  if (!fs.existsSync(dir)) return [];
+  const out = [];
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  for (const e of entries) {
+    const full = path.join(dir, e.name);
+    if (e.isDirectory()) out.push(...findFiles(full, pattern));
+    else if (pattern.test(e.name)) out.push(full);
+  }
+  return out;
+}
+
+function parseYaml(filePath) {
+  const raw = fs.readFileSync(filePath, 'utf8');
+  return yaml.load(raw);
+}
+
+function parseMarkdownFrontMatter(filePath) {
+  const raw = fs.readFileSync(filePath, 'utf8');
+  const m = raw.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!m) return null;
+  return yaml.load(m[1]);
+}
+
+function parseGherkinFrontMatter(filePath) {
+  const raw = fs.readFileSync(filePath, 'utf8');
+  const out = {};
+  for (const line of raw.split('\n')) {
+    const trimmed = line.trim();
+    if (trimmed === '') continue;
+    const m = trimmed.match(/^#\s+([a-z_-]+):\s*(.*)$/);
+    if (m) {
+      out[m[1]] = m[2].trim();
+    } else if (trimmed.startsWith('#')) {
+      continue;
+    } else {
+      break;
+    }
+  }
+  return Object.keys(out).length ? out : null;
+}
+
+function parseJsonFixture(filePath) {
+  const raw = fs.readFileSync(filePath, 'utf8');
+  return JSON.parse(raw);
+}
+
+function assertConforms(kind, file, data) {
+  if (data === null || data === undefined) {
+    assert.fail(`${path.relative(REPO_ROOT, file)}: no parseable content (expected ${kind} document or front-matter)`);
+  }
+  const validator = getValidator(kind);
+  const result = validator(data);
+  if (!result.valid) {
+    const detail = formatAjvErrors(result.errors).map((m) => `  - ${m}`).join('\n');
+    assert.fail(`${path.relative(REPO_ROOT, file)} failed ${kind} schema:\n${detail}`);
+  }
+}
+
+const PERSONA_FILES = findFiles(path.join(SPECS_ROOT, 'personas'), /\.md$/);
+const JOURNEY_FILES = findFiles(path.join(SPECS_ROOT, 'journeys'), /\.md$/);
+const STORY_FILES = findFiles(path.join(SPECS_ROOT, 'stories'), /\.md$/);
+const FEATURE_FILES = findFiles(path.join(SPECS_ROOT, 'features'), /\.feature$/);
+const MODEL_FILES = findFiles(path.join(SPECS_ROOT, 'models'), /\.model\.ya?ml$/);
+const LIFECYCLE_FILES = findFiles(path.join(SPECS_ROOT, 'models'), /\.lifecycle\.ya?ml$/);
+const JOURNEY_MAP_FILES = findFiles(path.join(SPECS_ROOT, 'journey-maps'), /\.(journey-map|map)\.ya?ml$/);
+const CAPABILITY_FILES = findFiles(path.join(SPECS_ROOT, 'capabilities'), /\.capability\.ya?ml$/);
+const FIXTURE_YAML_FILES = findFiles(path.join(SPECS_ROOT, 'fixtures'), /\.fixture\.ya?ml$/);
+const FIXTURE_JSON_FILES = findFiles(path.join(SPECS_ROOT, 'fixtures'), /\.json$/);
+
+test('schema registry loads', () => {
+  const index = loadIndex();
+  assert.equal(index.dialect, 'https://json-schema.org/draft/2020-12/schema');
+  assert.ok(index.artifacts && Object.keys(index.artifacts).length >= 8);
+});
+
+for (const file of PERSONA_FILES) {
+  test(`persona conforms: ${path.relative(REPO_ROOT, file)}`, () => {
+    assertConforms('persona', file, parseMarkdownFrontMatter(file));
+  });
+}
+
+for (const file of JOURNEY_FILES) {
+  test(`journey conforms: ${path.relative(REPO_ROOT, file)}`, () => {
+    assertConforms('journey', file, parseMarkdownFrontMatter(file));
+  });
+}
+
+for (const file of STORY_FILES) {
+  test(`story conforms: ${path.relative(REPO_ROOT, file)}`, () => {
+    assertConforms('story', file, parseMarkdownFrontMatter(file));
+  });
+}
+
+for (const file of FEATURE_FILES) {
+  test(`feature conforms: ${path.relative(REPO_ROOT, file)}`, () => {
+    assertConforms('feature', file, parseGherkinFrontMatter(file));
+  });
+}
+
+for (const file of MODEL_FILES) {
+  test(`model conforms: ${path.relative(REPO_ROOT, file)}`, () => {
+    assertConforms('model', file, parseYaml(file));
+  });
+}
+
+for (const file of LIFECYCLE_FILES) {
+  test(`lifecycle conforms: ${path.relative(REPO_ROOT, file)}`, () => {
+    assertConforms('lifecycle', file, parseYaml(file));
+  });
+}
+
+for (const file of JOURNEY_MAP_FILES) {
+  test(`journey-map conforms: ${path.relative(REPO_ROOT, file)}`, () => {
+    assertConforms('journey-map', file, parseYaml(file));
+  });
+}
+
+for (const file of CAPABILITY_FILES) {
+  test(`capability conforms: ${path.relative(REPO_ROOT, file)}`, () => {
+    assertConforms('capability', file, parseYaml(file));
+  });
+}
+
+for (const file of FIXTURE_YAML_FILES) {
+  test(`fixture (yaml) conforms: ${path.relative(REPO_ROOT, file)}`, () => {
+    assertConforms('fixture', file, parseYaml(file));
+  });
+}
+
+for (const file of FIXTURE_JSON_FILES) {
+  test(`fixture (json) conforms: ${path.relative(REPO_ROOT, file)}`, () => {
+    assertConforms('fixture', file, parseJsonFixture(file));
+  });
+}

--- a/tools/lib/schema-loader.js
+++ b/tools/lib/schema-loader.js
@@ -1,0 +1,108 @@
+/**
+ * Centralized loader for the IDD JSON Schemas published under schemas/v1/.
+ *
+ * Per-document grammars (shape, types, required fields, enums) live in the
+ * schemas. Validators load the schema once via getValidator(kind) and run it
+ * against parsed artifact content. Cross-document constraints — traceability,
+ * capability scope, fixture/contract binding, evidence — remain in imperative
+ * checkers and are not covered by this loader.
+ *
+ * See schemas/v1/index.json for the artifact registry and SCHEMA.md for the
+ * publication, versioning, and extension policy.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const Ajv = require('ajv/dist/2020');
+const addFormats = require('ajv-formats');
+
+const SCHEMAS_DIR = path.join(__dirname, '..', '..', 'schemas', 'v1');
+
+let cachedAjv = null;
+let cachedIndex = null;
+const validatorCache = new Map();
+
+function loadIndex() {
+  if (!cachedIndex) {
+    const raw = fs.readFileSync(path.join(SCHEMAS_DIR, 'index.json'), 'utf8');
+    cachedIndex = JSON.parse(raw);
+  }
+  return cachedIndex;
+}
+
+function loadAjv() {
+  if (cachedAjv) return cachedAjv;
+
+  const ajv = new Ajv({
+    strict: false,
+    allErrors: true,
+    allowUnionTypes: true,
+  });
+  addFormats(ajv);
+
+  const index = loadIndex();
+  for (const [, entry] of Object.entries(index.artifacts)) {
+    const schemaPath = path.join(SCHEMAS_DIR, entry.path);
+    const raw = fs.readFileSync(schemaPath, 'utf8');
+    const schema = JSON.parse(raw);
+    ajv.addSchema(schema, schema.$id);
+  }
+
+  cachedAjv = ajv;
+  return ajv;
+}
+
+/**
+ * Get a compiled validator for an artifact kind.
+ * @param {string} kind - one of the keys in schemas/v1/index.json#/artifacts
+ * @returns {(data: unknown) => { valid: boolean, errors: Array }}
+ */
+function getValidator(kind) {
+  if (validatorCache.has(kind)) {
+    return validatorCache.get(kind);
+  }
+
+  const ajv = loadAjv();
+  const index = loadIndex();
+  const entry = index.artifacts[kind];
+  if (!entry) {
+    throw new Error(`Unknown IDD artifact kind: ${kind}`);
+  }
+
+  const validate = ajv.getSchema(entry.$id);
+  if (!validate) {
+    throw new Error(`Schema for ${kind} could not be loaded (id: ${entry.$id})`);
+  }
+
+  const fn = (data) => {
+    const valid = validate(data);
+    return { valid, errors: validate.errors || [] };
+  };
+
+  validatorCache.set(kind, fn);
+  return fn;
+}
+
+/**
+ * Format ajv errors into short, human-readable strings.
+ */
+function formatAjvErrors(errors) {
+  if (!errors || errors.length === 0) return [];
+  return errors.map((err) => {
+    const where = err.instancePath || '(root)';
+    const detail = err.message || 'invalid';
+    if (err.keyword === 'additionalProperties' && err.params && err.params.additionalProperty) {
+      return `${where}: unknown property "${err.params.additionalProperty}"`;
+    }
+    if (err.keyword === 'enum' && err.params && err.params.allowedValues) {
+      return `${where}: ${detail} (allowed: ${err.params.allowedValues.join(', ')})`;
+    }
+    return `${where}: ${detail}`;
+  });
+}
+
+module.exports = {
+  getValidator,
+  formatAjvErrors,
+  loadIndex,
+};

--- a/tools/validate-capability-scope.js
+++ b/tools/validate-capability-scope.js
@@ -25,6 +25,7 @@ const fs = require('fs');
 const path = require('path');
 const yaml = require('js-yaml');
 const { findFiles, fileExists, formatResults } = require('./lib/parse-front-matter');
+const { getValidator, formatAjvErrors } = require('./lib/schema-loader');
 
 // ── Parse arguments ───────────────────────────────────────────────────
 const args = process.argv.slice(2);
@@ -84,14 +85,25 @@ function loadCapabilities() {
   const capDir = path.join(specsDir, 'capabilities');
   const capFiles = findFiles(capDir, /\.capability\.ya?ml$/);
   const capabilities = [];
+  const schemaErrors = [];
+  const validate = getValidator('capability');
 
   for (const capFile of capFiles) {
     try {
       const content = fs.readFileSync(capFile, 'utf8');
       const data = yaml.load(content);
+      const relative = path.relative(process.cwd(), capFile);
+      if (data && typeof data === 'object') {
+        const r = validate(data);
+        if (!r.valid) {
+          for (const msg of formatAjvErrors(r.errors)) {
+            schemaErrors.push(`${relative}: schema: ${msg}`);
+          }
+        }
+      }
       if (data && data.scope) {
         capabilities.push({
-          file: path.relative(process.cwd(), capFile),
+          file: relative,
           id: data.id || path.basename(capFile, '.capability.yaml'),
           scope: data.scope,
         });
@@ -101,7 +113,7 @@ function loadCapabilities() {
     }
   }
 
-  return capabilities;
+  return { capabilities, schemaErrors };
 }
 
 /**
@@ -163,7 +175,10 @@ function main() {
   const results = { errors: [], warnings: [], info: [] };
 
   // Load capabilities
-  const capabilities = loadCapabilities();
+  const { capabilities, schemaErrors } = loadCapabilities();
+  for (const msg of schemaErrors) {
+    results.errors.push(msg);
+  }
 
   if (capabilities.length === 0) {
     results.info.push('No capability files found in specs/capabilities/');

--- a/tools/validate-fixtures.js
+++ b/tools/validate-fixtures.js
@@ -25,6 +25,7 @@ const {
   protocolDisplayName,
 } = require('./lib/contracts');
 const { findFiles, formatResults, parseFrontMatter } = require('./lib/parse-front-matter');
+const { getValidator: getSchemaValidator, formatAjvErrors } = require('./lib/schema-loader');
 
 const args = process.argv.slice(2);
 let specsDir = null;
@@ -394,6 +395,12 @@ function validateFixture(fixturePath, index, schemas, ajv) {
 
   if (fixture.parseError) {
     return { valid: false, error: `Invalid fixture format: ${fixture.parseError}` };
+  }
+
+  const schemaResult = getSchemaValidator('fixture')(fixture);
+  if (!schemaResult.valid) {
+    const detail = formatAjvErrors(schemaResult.errors).join('; ');
+    return { valid: false, error: `Fixture schema: ${detail}` };
   }
 
   if (fixture._meta && typeof fixture._meta === 'object' && fixture._meta.schema) {

--- a/tools/validate-journey-maps.js
+++ b/tools/validate-journey-maps.js
@@ -16,6 +16,7 @@
 const fs = require('fs');
 const path = require('path');
 const { findFiles, formatResults, parseFrontMatter } = require('./lib/parse-front-matter');
+const { getValidator, formatAjvErrors } = require('./lib/schema-loader');
 
 const args = process.argv.slice(2);
 let specsDir = null;
@@ -195,6 +196,13 @@ function validateJourneyMap(filePath) {
 
   if (!map || typeof map !== 'object') {
     return { errors: ['YAML root must be an object'], warnings: [] };
+  }
+
+  const schemaCheck = getValidator('journey-map')(map);
+  if (!schemaCheck.valid) {
+    for (const msg of formatAjvErrors(schemaCheck.errors)) {
+      errors.push(`schema: ${msg}`);
+    }
   }
 
   if (!map.journey) {

--- a/tools/validate-models.js
+++ b/tools/validate-models.js
@@ -16,6 +16,7 @@
 const fs = require('fs');
 const path = require('path');
 const { findFiles, formatResults, parseFrontMatter } = require('./lib/parse-front-matter');
+const { getValidator, formatAjvErrors } = require('./lib/schema-loader');
 
 const args = process.argv.slice(2);
 let specsDir = null;
@@ -97,6 +98,14 @@ function validateModelFile(filePath) {
 
   if (!model || typeof model !== 'object') {
     return { errors: ['YAML root must be an object'], warnings };
+  }
+
+  const schemaKind = isLifecycle ? 'lifecycle' : 'model';
+  const schemaCheck = getValidator(schemaKind)(model);
+  if (!schemaCheck.valid) {
+    for (const msg of formatAjvErrors(schemaCheck.errors)) {
+      errors.push(`schema: ${msg}`);
+    }
   }
 
   if (isLifecycle) {


### PR DESCRIPTION
Closes #36.

## Summary

Stands up `schemas/v1/` as the canonical, machine-readable definition of the IDD specification format. Every validator, certification check, documentation generator, and downstream consumer should derive its understanding of the format from these schemas instead of from hand-written predicates.

**One schema per artifact kind** (JSON Schema Draft 2020-12):

- `persona.schema.json`, `journey.schema.json`, `story.schema.json`, `feature.schema.json` — front-matter for Markdown / Gherkin artifacts
- `model.schema.json`, `lifecycle.schema.json`, `journey-map.schema.json`, `capability.schema.json`, `fixture.schema.json` — full document grammars for YAML / JSON artifacts
- `index.json` — registry mapping each kind to its `\$id` and local path

All `\$id` URLs are under `https://github.com/slusset/intention-driven-design/schemas/v1/` so external tools can resolve them from `raw.githubusercontent.com` or from `node_modules/idd-toolkit/schemas/v1/`.

## Wiring

`tools/lib/schema-loader.js` loads every registered schema into a single ajv instance and exposes `getValidator(kind)`. Per-document validators (`validate-models`, `validate-journey-maps`, `validate-capability-scope`, `validate-fixtures`) now run the schema *before* their existing imperative checks. Schema errors surface as `schema: …` lines.

**This PR is strictly additive.** No existing rule is removed. Closed-world key validation, kinded grammars, and declarative shape selection arrive in #37 / #38 / #39 — those issues become schema extensions rather than new validator code.

## Per-document vs cross-document split

Per-document grammar (types, required fields, enums, structure) → schemas.
Cross-document constraints (traceability, capability scope coverage, fixture-payload-against-contract, evidence) → imperative checkers, unchanged. #40 (reference closure) and #41 (enforcement binding) extend the imperative layer.

## Documentation

`SCHEMA.md` covers: artifact set, JSON Schema dialect, version policy (semver), the extension model with forward-reference to #37's `\$conformance` tiers, the per-document vs cross-document split, how to add a new artifact kind, and how downstream tools consume the schemas (HTTP fetch, npm install, IDE integration via yaml-language-server).

## Conformance fixtures

`tests/schemas/conformance.test.js` ajv-validates every file under `specs/` against its registered schema. 23 tests pass (`npm test`). The `specs/` examples are now the conformance fixture set for the schemas themselves — drop a new spec file in the right directory and the test auto-discovers it.

## Test plan

- [x] All existing tests still pass (`npm test` → 23/23).
- [x] All validators still pass on `specs/` with no behavior change (`node tools/validate-models.js`, `validate-journey-maps`, `validate-capability-scope`, `validate-fixtures`).
- [x] Conformance suite picks up every spec file via directory discovery.

## What's next

Issues that build on this:

- #37 — closed-world key validation + `\$conformance` tiers (turn `additionalProperties: false` on, add the `canonical | legacy-compatible | experimental` marker)
- #38 — kinded grammars to replace closed enums (relationships, assertions, actions)
- #39 — declarative lifecycle and journey-map shapes (`bounded | unbounded | absorbing | cyclic`, `sequential | branching | hierarchical`)
- #40 — reference closure as a capability-scope obligation
- #41 — bind model `enforced:` rules to concrete enforcement points

🤖 Generated with [Claude Code](https://claude.com/claude-code)