### PR TITLE
Kinded grammars for relationships, actions, and assertions (#38)

### DIFF
--- a/SCHEMA.md
+++ b/SCHEMA.md
@@ -76,9 +76,10 @@ The schema set is versioned with semantic versioning:
   constraints that invalidate previously valid documents, removed artifact
   kinds. Major bumps ship with a documented migration path.
 
-The current version is **`1.1.0`** (declared in
+The current version is **`1.2.0`** (declared in
 [`schemas/v1/index.json`](schemas/v1/index.json)). Closed-world key validation
-with `$conformance` tiers landed in 1.1.
+with `$conformance` tiers landed in 1.1; kinded grammars for relationships,
+actions, and assertions landed in 1.2.
 
 When the major version increments, the new schemas are published under a new
 directory (`schemas/v2/`) and the previous directory is retained for backward
@@ -151,6 +152,96 @@ or ignore it.
 `$conformance` and `$conformance-notes` are reserved at every object level and
 are always accepted. They are metadata about the enclosing field, not part of
 its payload.
+
+## Kinded grammars (v1.2)
+
+Three slots previously expressed as closed enums are now kinded — they declare
+a `kind` and a set of attributes rather than collapsing a multi-attribute
+concept into a single token. The legacy names remain valid as **named
+combinations** that the validator expands. Authors can use either form; new
+documents are encouraged to use the expanded form where the additional axes
+are load-bearing.
+
+The authoritative table lives at
+[`tools/lib/kinds.js`](tools/lib/kinds.js).
+
+### Relationships
+
+Expanded form attributes:
+
+- `kind`: `composition` | `association` | `aggregation` | `pointer`
+- `cardinality`: `one-to-one` | `one-to-many` | `many-to-one` | `many-to-many`
+- `temporality`: `live` | `pinned` | `snapshotted` | `versioned`
+- `ownership`: `owned` | `not-owned`
+- `required`: boolean
+
+Named combinations:
+
+| Legacy `type` | `kind` | `cardinality` | `ownership` |
+|---|---|---|---|
+| `belongs-to` | association | many-to-one | not-owned |
+| `has-one` | composition | one-to-one | owned |
+| `has-many` | composition | one-to-many | owned |
+| `many-to-many` | association | many-to-many | not-owned |
+
+The new `pointer` kind covers cases like a `Scan` referencing a specific
+historical `TruthFileRevision` — neither owned by the scan nor live-tracking
+the latest revision. With `temporality: pinned` the read-only-pinned semantics
+are explicit:
+
+```yaml
+relationships:
+  pinnedRevision:
+    entity: TruthFileRevision
+    kind: pointer
+    cardinality: many-to-one
+    temporality: pinned
+```
+
+### Journey-map actions
+
+Expanded form attributes:
+
+- `kind`: `ui-interaction` | `navigation` | `wait` | `network`
+- `verb`: optional fine-grained verb (e.g., `double-click`)
+- `target`, `value`: as before
+
+Named combinations cover the Playwright vocabulary (`navigate`, `click`,
+`fill`, `select`, `check`, `uncheck`, `wait`, `hover`, `scroll`, `press`,
+`type`, `upload`). See `ACTION_COMBINATIONS` in
+[`tools/lib/kinds.js`](tools/lib/kinds.js).
+
+### Journey-map assertions
+
+Expanded form attributes:
+
+- `kind`: `dom` | `url` | `api` | `cookie` | `classification` | `tag` | `context`
+- `property`: per-kind property name (e.g., `visibility`, `text`, `set`,
+  `max-age`)
+- `target`: selector / URL / endpoint / cookie name / classification name / …
+- `expected`: as before
+- `selector`: legacy alias for `target` on DOM kinds
+
+Named combinations cover the legacy `visible | hidden | text | url | api |
+count | polling | attribute | value | enabled | disabled` vocabulary. New
+domain assertions like `kind: cookie, property: set, target: session-cookie`
+or `kind: classification, target: principal-classification` are first-class
+in v1.2.
+
+### Validator behavior
+
+When a slot carries a legacy `type`, the validator emits an INFO line showing
+the expansion so the underlying grammar is observable:
+
+```
+specs/models/scan.model.yaml: Relationship "owner" type:belongs-to ⇒ kind:association, cardinality:many-to-one, ownership:not-owned
+```
+
+When a slot carries both a legacy `type` and expanded fields that disagree
+with the named combination, the validator emits a WARNING listing each
+conflict. When a slot carries an unrecognized `type` (and no `kind`), the
+validator emits a WARNING suggesting either the known legacy names or the
+expanded form.
 
 ## Conformance fixtures
 

--- a/schemas/v1/index.json
+++ b/schemas/v1/index.json
@@ -3,7 +3,7 @@
   "$id": "https://github.com/slusset/intention-driven-design/schemas/v1/index.json",
   "title": "IDD Schema Registry (v1)",
   "description": "Registry of IDD schemas at v1. Each entry maps an artifact kind to its canonical $id and to the local path under schemas/v1/. Consumers should prefer the $id URL; local validators resolve via the path.",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "dialect": "https://json-schema.org/draft/2020-12/schema",
   "artifacts": {
     "persona": {

--- a/schemas/v1/journey-map.schema.json
+++ b/schemas/v1/journey-map.schema.json
@@ -86,10 +86,25 @@
     },
     "action": {
       "type": "object",
-      "required": ["type"],
+      "description": "A user or system action performed during a journey step. Either a legacy `type` (back-compat with the Playwright-vocab enum) or a kinded form (`kind` + attributes) must be present. The expanded form replaces the closed enum from v1.0 (see #38).",
+      "anyOf": [
+        { "required": ["type"] },
+        { "required": ["kind"] }
+      ],
       "additionalProperties": false,
       "properties": {
-        "type": { "type": "string" },
+        "type": {
+          "description": "Legacy action verb. Recognized values are navigate, click, fill, select, check, uncheck, wait, hover, scroll, press, type, upload. New documents are encouraged to use the expanded form.",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Broad category of action. ui-interaction covers DOM-level verbs (click/fill/hover/...); navigation covers route changes; wait covers explicit delays or polling; network covers requests issued directly by the test.",
+          "enum": ["ui-interaction", "navigation", "wait", "network"]
+        },
+        "verb": {
+          "description": "Optional fine-grained verb when `kind` alone is too coarse (e.g., kind:ui-interaction, verb:double-click).",
+          "type": "string"
+        },
         "target": { "type": ["string", "object"] },
         "value": {},
         "$conformance": { "$ref": "#/$defs/conformance" },
@@ -98,10 +113,29 @@
     },
     "assertion": {
       "type": "object",
-      "required": ["type"],
+      "description": "An expectation checked during a journey step. Either a legacy `type` (back-compat with the Playwright-vocab enum) or a kinded form (`kind` + property + target) must be present. The expanded form replaces the closed enum from v1.0 (see #38) and admits domain assertions (cookie state, principal classification, lead tag, intake prefill, …) that the legacy enum could not express.",
+      "anyOf": [
+        { "required": ["type"] },
+        { "required": ["kind"] }
+      ],
       "additionalProperties": false,
       "properties": {
-        "type": { "type": "string" },
+        "type": {
+          "description": "Legacy assertion name. Recognized values are visible, hidden, text, url, api, count, polling, attribute, value, enabled, disabled. New documents are encouraged to use the expanded form.",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Broad category of assertion. dom = visible elements / text / attributes; url = route or query state; api = network response; cookie = cookie state; classification / tag / context = domain-level assertions about the principal or scenario.",
+          "enum": ["dom", "url", "api", "cookie", "classification", "tag", "context"]
+        },
+        "property": {
+          "description": "What about the kind is being asserted. For dom: visibility | text | value | attribute | enabled | count. For url: matches | contains | query. For cookie: set | present | max-age. Open string because each kind has its own property vocabulary.",
+          "type": "string"
+        },
+        "target": {
+          "description": "What the assertion is about: a DOM selector, URL pattern, API endpoint, cookie name, classification name, tag name, or context key.",
+          "type": ["string", "object"]
+        },
         "selector": { "type": ["string", "object"] },
         "expected": {},
         "$conformance": { "$ref": "#/$defs/conformance" },

--- a/schemas/v1/model.schema.json
+++ b/schemas/v1/model.schema.json
@@ -100,10 +100,33 @@
     },
     "relationship": {
       "type": "object",
-      "required": ["type", "entity"],
+      "description": "A relationship between this model and another entity. Either a legacy `type` (back-compat) or an expanded kinded form (`kind` + attributes) — or both — must be present. The expanded form replaces the closed enum from v1.0 (see #38).",
+      "required": ["entity"],
+      "anyOf": [
+        { "required": ["type"] },
+        { "required": ["kind"] }
+      ],
       "additionalProperties": false,
       "properties": {
-        "type": { "type": "string" },
+        "type": {
+          "description": "Legacy relationship name. Recognized values are belongs-to, has-one, has-many, many-to-many. The validator expands each to its named combination of (kind, cardinality, ownership). New documents are encouraged to use the expanded form.",
+          "type": "string"
+        },
+        "kind": {
+          "description": "Structural nature of the relationship. composition (lifecycle-bound), association (independent), aggregation (whole/part without lifecycle ownership), pointer (read-only reference, often to a specific revision).",
+          "enum": ["composition", "association", "aggregation", "pointer"]
+        },
+        "cardinality": {
+          "enum": ["one-to-one", "one-to-many", "many-to-one", "many-to-many"]
+        },
+        "temporality": {
+          "description": "How time enters the reference. `live` follows the target; `pinned` references a specific revision; `snapshotted` carries an embedded copy; `versioned` tracks a specific version identifier.",
+          "enum": ["live", "pinned", "snapshotted", "versioned"]
+        },
+        "ownership": {
+          "enum": ["owned", "not-owned"]
+        },
+        "required": { "type": "boolean" },
         "entity": { "type": "string" },
         "description": { "type": "string" },
         "$conformance": { "$ref": "#/$defs/conformance" },

--- a/tests/schemas/kinded.test.js
+++ b/tests/schemas/kinded.test.js
@@ -1,0 +1,150 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  categorize,
+  RELATIONSHIP_COMBINATIONS,
+  ACTION_COMBINATIONS,
+  ASSERTION_COMBINATIONS,
+} = require('../../tools/lib/kinds');
+const { getValidator, loadIndex } = require('../../tools/lib/schema-loader');
+
+test('schema registry version is bumped to 1.2.x or later', () => {
+  const index = loadIndex();
+  const [maj, min] = index.version.split('.').map(Number);
+  assert.equal(maj, 1);
+  assert.ok(min >= 2, `expected minor >= 2 for the kinded-grammar bump, got ${index.version}`);
+});
+
+test('every legacy relationship name has a named-combination expansion', () => {
+  for (const name of ['belongs-to', 'has-one', 'has-many', 'many-to-many']) {
+    const r = categorize('relationship', { type: name, entity: 'X' });
+    assert.equal(r.status, 'expanded', `${name} should resolve to expanded`);
+    assert.ok(r.expansion.kind, `${name} expansion missing kind`);
+    assert.ok(r.expansion.cardinality, `${name} expansion missing cardinality`);
+  }
+});
+
+test('every legacy action verb has a named-combination expansion', () => {
+  for (const name of Object.keys(ACTION_COMBINATIONS)) {
+    const r = categorize('action', { type: name });
+    assert.equal(r.status, 'expanded', `${name} should resolve to expanded`);
+    assert.ok(r.expansion.kind, `${name} expansion missing kind`);
+  }
+});
+
+test('every legacy assertion name has a named-combination expansion', () => {
+  for (const name of Object.keys(ASSERTION_COMBINATIONS)) {
+    const r = categorize('assertion', { type: name });
+    assert.equal(r.status, 'expanded', `${name} should resolve to expanded`);
+    assert.ok(r.expansion.kind, `${name} expansion missing kind`);
+  }
+});
+
+test('expanded relationship form (pointer + pinned) is accepted without a legacy type', () => {
+  const rel = {
+    entity: 'TruthFileRevision',
+    kind: 'pointer',
+    temporality: 'pinned',
+    cardinality: 'many-to-one',
+  };
+  const r = categorize('relationship', rel);
+  assert.equal(r.status, 'kinded');
+  assert.equal(r.kind, 'pointer');
+});
+
+test('schema accepts the expanded relationship form', () => {
+  const model = {
+    id: 'scan',
+    type: 'model',
+    entity: 'Scan',
+    relationships: {
+      pinnedRevision: {
+        entity: 'TruthFileRevision',
+        kind: 'pointer',
+        temporality: 'pinned',
+        cardinality: 'many-to-one',
+      },
+    },
+  };
+  const result = getValidator('model')(model);
+  assert.ok(result.valid, `expected valid, errors: ${JSON.stringify(result.errors)}`);
+});
+
+test('schema accepts the expanded assertion form (cookie kind)', () => {
+  const map = {
+    id: 'auth',
+    type: 'journey-map',
+    journey: 'auth',
+    steps: [
+      {
+        id: 'sign-in',
+        assertions: [
+          { kind: 'cookie', property: 'set', target: 'session-cookie' },
+        ],
+      },
+    ],
+  };
+  const result = getValidator('journey-map')(map);
+  assert.ok(result.valid, `expected valid, errors: ${JSON.stringify(result.errors)}`);
+});
+
+test('schema accepts the expanded assertion form (classification kind)', () => {
+  const map = {
+    id: 'auth',
+    type: 'journey-map',
+    journey: 'auth',
+    steps: [
+      {
+        id: 'classify-principal',
+        assertions: [
+          { kind: 'classification', target: 'principal-classification', expected: 'returning' },
+        ],
+      },
+    ],
+  };
+  const result = getValidator('journey-map')(map);
+  assert.ok(result.valid, `expected valid, errors: ${JSON.stringify(result.errors)}`);
+});
+
+test('relationship requires either type or kind', () => {
+  const result = getValidator('model')({
+    id: 'x', type: 'model', entity: 'X',
+    relationships: { y: { entity: 'Y' } },
+  });
+  assert.ok(!result.valid, 'expected invalid when relationship has neither type nor kind');
+});
+
+test('action requires either type or kind', () => {
+  const result = getValidator('journey-map')({
+    id: 'x', type: 'journey-map', journey: 'x',
+    steps: [{ id: 'a', actions: [{ target: '#btn' }] }],
+  });
+  assert.ok(!result.valid, 'expected invalid when action has neither type nor kind');
+});
+
+test('mixed form (legacy type + expanded fields that conflict) surfaces conflicts', () => {
+  const rel = {
+    entity: 'Y',
+    type: 'belongs-to',
+    kind: 'composition', // conflicts with belongs-to → association
+  };
+  const r = categorize('relationship', rel);
+  assert.equal(r.status, 'mixed');
+  assert.ok(r.conflicts.length > 0);
+  assert.ok(r.conflicts.some((c) => c.includes('kind')), `expected kind conflict, got ${JSON.stringify(r.conflicts)}`);
+});
+
+test('unknown relationship type with no kind returns status: unknown with legacyType set', () => {
+  const r = categorize('relationship', { type: 'references', entity: 'X' });
+  assert.equal(r.status, 'unknown');
+  assert.equal(r.legacyType, 'references');
+});
+
+test('relationship named-combinations cover the load-bearing four', () => {
+  assert.deepEqual(Object.keys(RELATIONSHIP_COMBINATIONS).sort(), [
+    'belongs-to', 'has-many', 'has-one', 'many-to-many',
+  ]);
+});

--- a/tools/lib/kinds.js
+++ b/tools/lib/kinds.js
@@ -1,0 +1,167 @@
+/**
+ * Named-combination registry for kinded grammars (#38).
+ *
+ * Each legacy `type` value (in relationships, actions, assertions) is a named
+ * combination of attributes in the expanded kinded form. The validator
+ * resolves a legacy name to its expansion and reports the expanded attributes
+ * so authors see the underlying grammar even when they wrote the short name.
+ *
+ * Adding a new kind is purely additive: extend the schema's enum for `kind`
+ * (if appropriate), and — if the new kind has a stable short name — register
+ * it here. Authors can also use the expanded form directly without a short
+ * name; the validator accepts that and skips the expansion step.
+ */
+
+const RELATIONSHIP_COMBINATIONS = {
+  'belongs-to': {
+    kind: 'association',
+    cardinality: 'many-to-one',
+    ownership: 'not-owned',
+  },
+  'has-one': {
+    kind: 'composition',
+    cardinality: 'one-to-one',
+    ownership: 'owned',
+  },
+  'has-many': {
+    kind: 'composition',
+    cardinality: 'one-to-many',
+    ownership: 'owned',
+  },
+  'many-to-many': {
+    kind: 'association',
+    cardinality: 'many-to-many',
+    ownership: 'not-owned',
+  },
+};
+
+const ACTION_COMBINATIONS = {
+  navigate: { kind: 'navigation', verb: 'navigate' },
+  click: { kind: 'ui-interaction', verb: 'click' },
+  fill: { kind: 'ui-interaction', verb: 'fill' },
+  select: { kind: 'ui-interaction', verb: 'select' },
+  check: { kind: 'ui-interaction', verb: 'check' },
+  uncheck: { kind: 'ui-interaction', verb: 'uncheck' },
+  wait: { kind: 'wait', verb: 'wait' },
+  hover: { kind: 'ui-interaction', verb: 'hover' },
+  scroll: { kind: 'ui-interaction', verb: 'scroll' },
+  press: { kind: 'ui-interaction', verb: 'press' },
+  type: { kind: 'ui-interaction', verb: 'type' },
+  upload: { kind: 'ui-interaction', verb: 'upload' },
+};
+
+const ASSERTION_COMBINATIONS = {
+  visible: { kind: 'dom', property: 'visibility', expected: 'visible' },
+  hidden: { kind: 'dom', property: 'visibility', expected: 'hidden' },
+  text: { kind: 'dom', property: 'text' },
+  url: { kind: 'url', property: 'matches' },
+  api: { kind: 'api' },
+  count: { kind: 'dom', property: 'count' },
+  polling: { kind: 'api', property: 'polling' },
+  attribute: { kind: 'dom', property: 'attribute' },
+  value: { kind: 'dom', property: 'value' },
+  enabled: { kind: 'dom', property: 'enabled', expected: true },
+  disabled: { kind: 'dom', property: 'enabled', expected: false },
+};
+
+const RELATIONSHIP_KINDS = new Set(['composition', 'association', 'aggregation', 'pointer']);
+const ACTION_KINDS = new Set(['ui-interaction', 'navigation', 'wait', 'network']);
+const ASSERTION_KINDS = new Set(['dom', 'url', 'api', 'cookie', 'classification', 'tag', 'context']);
+
+function describeCombination(combination) {
+  return Object.entries(combination)
+    .map(([k, v]) => `${k}:${v}`)
+    .join(', ');
+}
+
+/**
+ * Resolve a slot (relationship / action / assertion) into a categorization.
+ *
+ * Inputs:
+ *   - slot: 'relationship' | 'action' | 'assertion'
+ *   - value: the user's object, e.g. { type: 'belongs-to', entity: 'X' }
+ *
+ * Returns:
+ *   {
+ *     status: 'expanded' | 'kinded' | 'unknown' | 'mixed',
+ *     legacyType?: string,
+ *     kind?: string,
+ *     expansion?: object,            // present when status === 'expanded' or 'mixed'
+ *     description?: string,          // human-readable expansion summary
+ *     conflicts?: string[],          // present when status === 'mixed' and the
+ *                                    //   author-provided fields conflict with the
+ *                                    //   named-combination values
+ *   }
+ */
+function categorize(slot, value) {
+  if (!value || typeof value !== 'object') {
+    return { status: 'unknown' };
+  }
+
+  const table =
+    slot === 'relationship' ? RELATIONSHIP_COMBINATIONS :
+    slot === 'action' ? ACTION_COMBINATIONS :
+    slot === 'assertion' ? ASSERTION_COMBINATIONS :
+    null;
+
+  const validKinds =
+    slot === 'relationship' ? RELATIONSHIP_KINDS :
+    slot === 'action' ? ACTION_KINDS :
+    slot === 'assertion' ? ASSERTION_KINDS :
+    null;
+
+  if (!table) return { status: 'unknown' };
+
+  const legacyType = typeof value.type === 'string' ? value.type : null;
+  const declaredKind = typeof value.kind === 'string' ? value.kind : null;
+
+  if (legacyType && table[legacyType]) {
+    const expansion = table[legacyType];
+    if (declaredKind) {
+      const conflicts = [];
+      for (const [k, v] of Object.entries(expansion)) {
+        if (value[k] !== undefined && value[k] !== v) {
+          conflicts.push(`${k}: declared=${value[k]}, named-combination=${v}`);
+        }
+      }
+      return {
+        status: 'mixed',
+        legacyType,
+        kind: declaredKind,
+        expansion,
+        description: describeCombination(expansion),
+        conflicts,
+      };
+    }
+    return {
+      status: 'expanded',
+      legacyType,
+      expansion,
+      description: describeCombination(expansion),
+    };
+  }
+
+  if (declaredKind) {
+    if (!validKinds.has(declaredKind)) {
+      return { status: 'unknown', kind: declaredKind };
+    }
+    return { status: 'kinded', kind: declaredKind };
+  }
+
+  if (legacyType) {
+    return { status: 'unknown', legacyType };
+  }
+
+  return { status: 'unknown' };
+}
+
+module.exports = {
+  RELATIONSHIP_COMBINATIONS,
+  ACTION_COMBINATIONS,
+  ASSERTION_COMBINATIONS,
+  RELATIONSHIP_KINDS,
+  ACTION_KINDS,
+  ASSERTION_KINDS,
+  categorize,
+  describeCombination,
+};

--- a/tools/validate-journey-maps.js
+++ b/tools/validate-journey-maps.js
@@ -17,6 +17,7 @@ const fs = require('fs');
 const path = require('path');
 const { findFiles, formatResults, parseFrontMatter } = require('./lib/parse-front-matter');
 const { getValidator, categorize } = require('./lib/schema-loader');
+const { categorize: categorizeKind } = require('./lib/kinds');
 
 const args = process.argv.slice(2);
 let specsDir = null;
@@ -49,12 +50,14 @@ if (!specsDir) {
 const JOURNEY_MAPS_DIR = path.join(specsDir, 'journey-maps');
 const MAP_PATTERN = /\.(?:map|journey-map)\.ya?ml$/i;
 
-const VALID_ACTION_TYPES = [
+// Legacy enums retained for messages. Authoritative vocabulary lives in
+// tools/lib/kinds.js (ACTION_COMBINATIONS, ASSERTION_COMBINATIONS).
+const LEGACY_ACTION_TYPES = [
   'navigate', 'click', 'fill', 'select', 'check', 'uncheck',
   'wait', 'hover', 'scroll', 'press', 'type', 'upload',
 ];
 
-const VALID_ASSERTION_TYPES = [
+const LEGACY_ASSERTION_TYPES = [
   'visible', 'hidden', 'text', 'url', 'api', 'count',
   'polling', 'attribute', 'value', 'enabled', 'disabled',
 ];
@@ -81,7 +84,7 @@ function expectedJourneyFromFilename(filePath) {
     .replace(/\.map\.ya?ml$/i, '');
 }
 
-function validateLegacyStepModel(map, errors, warnings) {
+function validateLegacyStepModel(map, errors, warnings, info) {
   if (!map.steps || typeof map.steps !== 'object' || Array.isArray(map.steps)) {
     errors.push('Missing required field: steps (legacy object format)');
     return;
@@ -118,11 +121,16 @@ function validateLegacyStepModel(map, errors, warnings) {
           continue;
         }
 
-        if (!action.type) {
-          errors.push(`Step "${stepId}" has action without type`);
-        } else if (!VALID_ACTION_TYPES.includes(action.type)) {
-          warnings.push(`Step "${stepId}" has unknown action type: ${action.type}`);
-        }
+        applyKindedCheck({
+          slot: 'action',
+          value: action,
+          context: `Step "${stepId}" action`,
+          legacyNames: LEGACY_ACTION_TYPES,
+          validKindsHint: 'ui-interaction, navigation, wait, network',
+          errors,
+          warnings,
+          info,
+        });
 
         if (action.target && !String(action.target).includes('data-testid')) {
           warnings.push(`Step "${stepId}" action target doesn't use data-testid: ${action.target}`);
@@ -137,11 +145,16 @@ function validateLegacyStepModel(map, errors, warnings) {
           continue;
         }
 
-        if (!assertion.type) {
-          errors.push(`Step "${stepId}" has assertion without type`);
-        } else if (!VALID_ASSERTION_TYPES.includes(assertion.type)) {
-          warnings.push(`Step "${stepId}" has unknown assertion type: ${assertion.type}`);
-        }
+        applyKindedCheck({
+          slot: 'assertion',
+          value: assertion,
+          context: `Step "${stepId}" assertion`,
+          legacyNames: LEGACY_ASSERTION_TYPES,
+          validKindsHint: 'dom, url, api, cookie, classification, tag, context',
+          errors,
+          warnings,
+          info,
+        });
 
         if (assertion.selector && !String(assertion.selector).includes('data-testid')) {
           warnings.push(`Step "${stepId}" assertion selector doesn't use data-testid: ${assertion.selector}`);
@@ -151,7 +164,29 @@ function validateLegacyStepModel(map, errors, warnings) {
   }
 }
 
-function validateCurrentStepModel(map, errors, warnings) {
+function applyKindedCheck({ slot, value, context, legacyNames, validKindsHint, errors, warnings, info }) {
+  const result = categorizeKind(slot, value);
+  if (result.status === 'expanded') {
+    info.push(`${context} type:${result.legacyType} ⇒ ${result.description}`);
+  } else if (result.status === 'kinded') {
+    // expanded form, no legacy name — self-describing
+  } else if (result.status === 'mixed') {
+    info.push(`${context} type:${result.legacyType} ⇒ ${result.description}`);
+    for (const conflict of result.conflicts) {
+      warnings.push(`${context} conflict between legacy type and expanded form — ${conflict}`);
+    }
+  } else if (result.status === 'unknown') {
+    if (result.legacyType) {
+      warnings.push(`${context} has unrecognized type: ${result.legacyType}. Known legacy names: ${legacyNames.join(', ')}. Or use the expanded form with kind/property/target.`);
+    } else if (result.kind) {
+      warnings.push(`${context} has unknown kind: ${result.kind}. Allowed kinds: ${validKindsHint}.`);
+    } else {
+      errors.push(`${context} missing type or kind`);
+    }
+  }
+}
+
+function validateCurrentStepModel(map, errors, warnings, info = []) {
   if (!Array.isArray(map.steps) || map.steps.length === 0) {
     errors.push('Missing required field: steps (array format)');
     return;
@@ -181,21 +216,22 @@ function validateCurrentStepModel(map, errors, warnings) {
 function validateJourneyMap(filePath) {
   const errors = [];
   const warnings = [];
+  const info = [];
 
   let map;
   try {
     const content = fs.readFileSync(filePath, 'utf8');
     const parsed = parseFrontMatter(filePath, content);
     if (parsed.parseError) {
-      return { errors: [`Invalid YAML or unreadable file: ${parsed.parseError}`], warnings: [] };
+      return { errors: [`Invalid YAML or unreadable file: ${parsed.parseError}`], warnings: [], info: [] };
     }
     map = parsed.body;
   } catch (error) {
-    return { errors: [`Invalid YAML or unreadable file: ${error.message}`], warnings: [] };
+    return { errors: [`Invalid YAML or unreadable file: ${error.message}`], warnings: [], info: [] };
   }
 
   if (!map || typeof map !== 'object') {
-    return { errors: ['YAML root must be an object'], warnings: [] };
+    return { errors: ['YAML root must be an object'], warnings: [], info: [] };
   }
 
   const schemaCheck = getValidator('journey-map')(map);
@@ -218,12 +254,12 @@ function validateJourneyMap(filePath) {
   }
 
   if (Array.isArray(map.steps)) {
-    validateCurrentStepModel(map, errors, warnings);
+    validateCurrentStepModel(map, errors, warnings, info);
   } else {
-    validateLegacyStepModel(map, errors, warnings);
+    validateLegacyStepModel(map, errors, warnings, info);
   }
 
-  return { errors, warnings };
+  return { errors, warnings, info };
 }
 
 function outputResults(results) {
@@ -248,7 +284,7 @@ function main() {
 
   for (const mapFile of mapFiles) {
     const relativePath = path.relative(process.cwd(), mapFile);
-    const { errors, warnings } = validateJourneyMap(mapFile);
+    const { errors, warnings, info = [] } = validateJourneyMap(mapFile);
 
     for (const error of errors) {
       results.errors.push(`${relativePath}: ${error}`);
@@ -256,6 +292,10 @@ function main() {
 
     for (const warning of warnings) {
       results.warnings.push(`${relativePath}: ${warning}`);
+    }
+
+    for (const item of info) {
+      results.info.push(`${relativePath}: ${item}`);
     }
 
     if (errors.length === 0 && warnings.length === 0) {

--- a/tools/validate-models.js
+++ b/tools/validate-models.js
@@ -17,6 +17,7 @@ const fs = require('fs');
 const path = require('path');
 const { findFiles, formatResults, parseFrontMatter } = require('./lib/parse-front-matter');
 const { getValidator, categorize } = require('./lib/schema-loader');
+const { categorize: categorizeKind } = require('./lib/kinds');
 
 const args = process.argv.slice(2);
 let specsDir = null;
@@ -53,7 +54,9 @@ const VALID_TYPES = [
   'enum', 'array', 'object', 'uuid', 'ulid', 'email', 'url', 'uri',
 ];
 
-const VALID_RELATIONSHIP_TYPES = [
+// Legacy enum retained as documentation for the named-combinations table.
+// Authoritative vocabulary lives in tools/lib/kinds.js (RELATIONSHIP_COMBINATIONS).
+const LEGACY_RELATIONSHIP_TYPES = [
   'belongs-to', 'has-one', 'has-many', 'many-to-many',
 ];
 
@@ -80,24 +83,25 @@ function collectModelFiles() {
 function validateModelFile(filePath) {
   const errors = [];
   const warnings = [];
+  const info = [];
   const isLifecycle = /\.lifecycle\.ya?ml$/i.test(filePath);
 
   let content;
   try {
     content = fs.readFileSync(filePath, 'utf8');
   } catch (error) {
-    return { errors: [`Cannot read file: ${error.message}`], warnings: [] };
+    return { errors: [`Cannot read file: ${error.message}`], warnings: [], info: [] };
   }
 
   const parsed = parseFrontMatter(filePath, content);
   if (parsed.parseError) {
-    return { errors: [`Invalid YAML: ${parsed.parseError}`], warnings: [] };
+    return { errors: [`Invalid YAML: ${parsed.parseError}`], warnings: [], info: [] };
   }
 
   const model = parsed.body;
 
   if (!model || typeof model !== 'object') {
-    return { errors: ['YAML root must be an object'], warnings };
+    return { errors: ['YAML root must be an object'], warnings, info };
   }
 
   const schemaKind = isLifecycle ? 'lifecycle' : 'model';
@@ -111,10 +115,11 @@ function validateModelFile(filePath) {
   }
 
   if (isLifecycle) {
-    return validateLifecycle(model, errors, warnings);
+    return validateLifecycle(model, errors, warnings, info);
   }
 
-  return validateModelDocument(model, errors, warnings);
+  const r = validateModelDocument(model, errors, warnings, info);
+  return { ...r, info: r.info || info };
 }
 
 function isObject(value) {
@@ -145,7 +150,7 @@ function validateAttributeBlock(block, blockLabel, itemLabel, errors, warnings) 
   }
 }
 
-function validateRelationshipBlock(relationships, errors, warnings) {
+function validateRelationshipBlock(relationships, errors, warnings, info) {
   if (!isObject(relationships)) {
     errors.push('Relationships must be an object');
     return;
@@ -157,14 +162,29 @@ function validateRelationshipBlock(relationships, errors, warnings) {
       continue;
     }
 
-    if (!rel.type) {
-      errors.push(`Relationship "${relName}" missing type`);
-    } else if (!VALID_RELATIONSHIP_TYPES.includes(rel.type)) {
-      warnings.push(`Relationship "${relName}" has unknown type: ${rel.type}`);
-    }
-
     if (!rel.entity) {
       errors.push(`Relationship "${relName}" missing target entity`);
+    }
+
+    const result = categorizeKind('relationship', rel);
+
+    if (result.status === 'expanded') {
+      info.push(`Relationship "${relName}" type:${result.legacyType} ⇒ ${result.description}`);
+    } else if (result.status === 'kinded') {
+      // expanded form, no legacy name — already self-describing
+    } else if (result.status === 'mixed') {
+      info.push(`Relationship "${relName}" type:${result.legacyType} ⇒ ${result.description}`);
+      for (const conflict of result.conflicts) {
+        warnings.push(`Relationship "${relName}" conflict between legacy type and expanded form — ${conflict}`);
+      }
+    } else if (result.status === 'unknown') {
+      if (result.legacyType) {
+        warnings.push(`Relationship "${relName}" has unrecognized type: ${result.legacyType}. Known legacy names: ${LEGACY_RELATIONSHIP_TYPES.join(', ')}. Or use the expanded form with kind/cardinality/ownership/temporality.`);
+      } else if (result.kind) {
+        warnings.push(`Relationship "${relName}" has unknown kind: ${result.kind}. Allowed kinds: composition, association, aggregation, pointer.`);
+      } else {
+        errors.push(`Relationship "${relName}" missing type or kind`);
+      }
     }
   }
 }
@@ -195,7 +215,7 @@ function validateSources(model, label, warnings) {
   }
 }
 
-function validateEntityModel(model, errors, warnings) {
+function validateEntityModel(model, errors, warnings, info) {
   if (!model.description) {
     warnings.push('Entity should have a description');
   }
@@ -216,7 +236,7 @@ function validateEntityModel(model, errors, warnings) {
   }
 
   if (model.relationships) {
-    validateRelationshipBlock(model.relationships, errors, warnings);
+    validateRelationshipBlock(model.relationships, errors, warnings, info);
   }
 
   if (model.rules) {
@@ -322,37 +342,37 @@ function validateValueObjectBundle(model, errors, warnings) {
   validateSources(model, 'Shared value object bundle', warnings);
 }
 
-function validateModelDocument(model, errors, warnings) {
+function validateModelDocument(model, errors, warnings, info = []) {
   if (model.entity) {
-    validateEntityModel(model, errors, warnings);
-    return { errors, warnings };
+    validateEntityModel(model, errors, warnings, info);
+    return { errors, warnings, info };
   }
 
   if (model.value_object) {
     validateSources(model, 'Value object', warnings);
-    return { errors, warnings };
+    return { errors, warnings, info };
   }
 
   if (model.aggregate) {
     validateAggregateModel(model, errors, warnings);
-    return { errors, warnings };
+    return { errors, warnings, info };
   }
 
   if (model.catalog) {
     validateCatalogModel(model, errors, warnings);
-    return { errors, warnings };
+    return { errors, warnings, info };
   }
 
   if (model.value_objects) {
     validateValueObjectBundle(model, errors, warnings);
-    return { errors, warnings };
+    return { errors, warnings, info };
   }
 
   errors.push('Model must have one of "entity", "value_object", "aggregate", "catalog", or "value_objects"');
-  return { errors, warnings };
+  return { errors, warnings, info };
 }
 
-function validateLifecycle(model, errors, warnings) {
+function validateLifecycle(model, errors, warnings, info = []) {
   if (!model.entity) {
     errors.push('Lifecycle must specify entity');
   }
@@ -363,7 +383,7 @@ function validateLifecycle(model, errors, warnings) {
 
   if (!model.states || typeof model.states !== 'object') {
     errors.push('Lifecycle must define states');
-    return { errors, warnings };
+    return { errors, warnings, info };
   }
 
   const stateNames = Object.keys(model.states);
@@ -412,7 +432,7 @@ function validateLifecycle(model, errors, warnings) {
     }
   }
 
-  return { errors, warnings };
+  return { errors, warnings, info };
 }
 
 function outputResults(results) {
@@ -437,7 +457,7 @@ function main() {
 
   for (const modelFile of modelFiles) {
     const relativePath = path.relative(process.cwd(), modelFile);
-    const { errors, warnings } = validateModelFile(modelFile);
+    const { errors, warnings, info = [] } = validateModelFile(modelFile);
 
     for (const error of errors) {
       results.errors.push(`${relativePath}: ${error}`);
@@ -445,6 +465,10 @@ function main() {
 
     for (const warning of warnings) {
       results.warnings.push(`${relativePath}: ${warning}`);
+    }
+
+    for (const item of info) {
+      results.info.push(`${relativePath}: ${item}`);
     }
 
     if (errors.length === 0 && warnings.length === 0) {


### PR DESCRIPTION
Closes #38.

## Summary

Three slots previously collapsed into single-token enums now declare a `kind` and a set of attributes. The four/twelve/eleven legacy enum values remain valid as **named combinations** that the validator expands; new documents can use the expanded form directly.

| Slot | Legacy enum | Expanded attributes |
|---|---|---|
| Relationship | belongs-to, has-one, has-many, many-to-many | kind, cardinality, temporality, ownership, required |
| Action | navigate, click, fill, …, upload (12 values) | kind, verb, target, value |
| Assertion | visible, hidden, text, …, disabled (11 values) | kind, property, target, expected |

## The wedge — `pointer` + `temporality: pinned`

The relationship vocabulary specifically fails on the case raised in `slusset/edyoucate-ai#423`: a `Scan` that references a *specific historical* `TruthFileRevision`. The legacy enum forced `belongs-to`, which loses the read-only-pinned semantics. v1.2 adds the `pointer` kind with `temporality: pinned`:

```yaml
relationships:
  pinnedRevision:
    entity: TruthFileRevision
    kind: pointer
    cardinality: many-to-one
    temporality: pinned
```

This satisfies the issue's acceptance criterion to add at least one new kind beyond the legacy enums.

## Authoritative registry

`tools/lib/kinds.js` holds the named-combinations table. Both validators consume it through `categorize(slot, value)`. Adding a new combination is one entry; adding a new kind is one entry in the schema enum plus (optionally) a named-combination entry if it has a stable short name.

## Validator behavior

- **Legacy name only** → INFO: `Relationship "owner" type:belongs-to ⇒ kind:association, cardinality:many-to-one, ownership:not-owned`
- **Expanded form only** → silently accepted (self-describing)
- **Mixed form with conflicting attributes** → WARNING per conflict
- **Unknown legacy type, no `kind`** → WARNING with the known-names list and the expanded-form hint
- **Neither `type` nor `kind`** → ERROR (schema-enforced via `anyOf`)

## Documentation

`SCHEMA.md` adds the kinded-grammar section with full named-combination tables and the validator-behavior summary. Schema registry bumped to **1.2.0**.

## Tests

`tests/schemas/kinded.test.js` (13 cases) covers:
- Every legacy name resolves to a named combination (relationships, actions, assertions)
- Expanded form is accepted standalone — including the new `pointer` kind, cookie assertion, classification assertion
- Mixed forms with conflicts are detected
- `anyOf(type | kind)` is schema-enforced
- Schema registry version is ≥ 1.2

Full suite: **43/43 passing** (\`npm test\`).

## What's next

#39 — declarative lifecycle and journey-map shapes (`bounded | unbounded | branching`). Like #38, this becomes a strictly additive schema change now that closed-world + kinded grammars are in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)