### PR TITLE
Declarative lifecycle and journey-map shapes (#39)

### DIFF
--- a/SCHEMA.md
+++ b/SCHEMA.md
@@ -76,10 +76,11 @@ The schema set is versioned with semantic versioning:
   constraints that invalidate previously valid documents, removed artifact
   kinds. Major bumps ship with a documented migration path.
 
-The current version is **`1.2.0`** (declared in
+The current version is **`1.3.0`** (declared in
 [`schemas/v1/index.json`](schemas/v1/index.json)). Closed-world key validation
 with `$conformance` tiers landed in 1.1; kinded grammars for relationships,
-actions, and assertions landed in 1.2.
+actions, and assertions landed in 1.2; declarative lifecycle and journey-map
+shapes landed in 1.3.
 
 When the major version increments, the new schemas are published under a new
 directory (`schemas/v2/`) and the previous directory is retained for backward
@@ -242,6 +243,78 @@ with the named combination, the validator emits a WARNING listing each
 conflict. When a slot carries an unrecognized `type` (and no `kind`), the
 validator emits a WARNING suggesting either the known legacy names or the
 expanded form.
+
+## Declarative shapes (v1.3)
+
+Two artifact kinds previously had a fixed grammar baked into the validator —
+lifecycles required a terminal state, journey maps required strictly increasing
+`journey_step` numbers. Both rules are correct for the common case and misfire
+on legitimate alternatives.
+
+v1.3 makes the shape explicit. The author declares the kind of artifact, and
+the validator applies the matching rule set. The default for each is the
+previous rule, so existing files remain valid.
+
+### Lifecycle shapes
+
+`shape` is an optional top-level field on `.lifecycle.yaml`:
+
+| Shape | Default rule | Use for |
+|---|---|---|
+| `bounded` (default) | at least one terminal state required | Order, Audit, Signup |
+| `absorbing` | at least one terminal state required | Order (one reachable terminal) |
+| `unbounded` | terminal state NOT required | Customer, TruthFile, BusinessAccount |
+| `cyclic` | terminal state NOT required; transitions may return to initial | Subscription, Membership |
+
+When `shape: unbounded` (or `cyclic`) is declared, the "Lifecycle should have at
+least one terminal state" warning is silenced.
+
+```yaml
+id: truth-file-lifecycle
+type: model
+entity: TruthFile
+shape: unbounded
+initial_state: active
+states:
+  active:
+    description: "The canonical record for the customer's full lifetime."
+```
+
+### Journey-map shapes
+
+`shape` is an optional top-level field on `.journey-map.yaml`:
+
+| Shape | Default rule | Use for |
+|---|---|---|
+| `sequential` (default) | strictly increasing `journey_step` | Linear flows |
+| `branching` | duplicate `journey_step` numbers allowed when each step has a `branch:` key | Magic-link redemption (link vs code), retry alternates |
+| `hierarchical` | sub-step notation (`3a`, `3b`) accepted in `journey_step` | Nested journeys |
+
+Under `shape: branching`, each step at a shared step number declares which
+branch it belongs to:
+
+```yaml
+shape: branching
+steps:
+  exchange-link:
+    journey_step: 3
+    branch: link-redeem
+  exchange-code:
+    journey_step: 3
+    branch: code-redeem
+```
+
+The validator emits an INFO line summarizing each fan-out (`shape:branching —
+journey_step 3 fans out across branches: link-redeem, code-redeem`) and warns
+when a step under `shape: branching` is missing its `branch:` key.
+
+### Why this inverts the relationship
+
+The previous rules assumed one grammar and warned on everything else. The
+shape selector inverts that: the author tells the validator what kind of
+artifact this is, and the validator applies the matching rule set. That is
+the load-bearing move — it replaces an assumed grammar with a chosen
+grammar.
 
 ## Conformance fixtures
 

--- a/schemas/v1/index.json
+++ b/schemas/v1/index.json
@@ -3,7 +3,7 @@
   "$id": "https://github.com/slusset/intention-driven-design/schemas/v1/index.json",
   "title": "IDD Schema Registry (v1)",
   "description": "Registry of IDD schemas at v1. Each entry maps an artifact kind to its canonical $id and to the local path under schemas/v1/. Consumers should prefer the $id URL; local validators resolve via the path.",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "dialect": "https://json-schema.org/draft/2020-12/schema",
   "artifacts": {
     "persona": {

--- a/schemas/v1/journey-map.schema.json
+++ b/schemas/v1/journey-map.schema.json
@@ -10,6 +10,11 @@
     "id": { "type": "string", "minLength": 1 },
     "type": { "const": "journey-map" },
     "journey": { "type": "string", "minLength": 1 },
+    "shape": {
+      "description": "Declarative journey-map shape (#39). Selects which step-ordering rule applies. Default is `sequential` for back-compat.",
+      "enum": ["sequential", "branching", "hierarchical"],
+      "default": "sequential"
+    },
     "sources": {
       "type": "object",
       "additionalProperties": false,
@@ -60,6 +65,10 @@
           "story": { "type": "string" },
           "title": { "type": "string" },
           "journey_step": { "type": ["integer", "string"] },
+          "branch": {
+            "description": "Used with shape:branching. Distinguishes steps that share a journey_step number by naming the branch the step belongs to.",
+            "type": "string"
+          },
           "actions": { "type": "array", "items": { "$ref": "#/$defs/action" } },
           "assertions": { "type": "array", "items": { "$ref": "#/$defs/assertion" } },
           "$conformance": { "$ref": "#/$defs/conformance" },
@@ -74,9 +83,10 @@
         "required": ["journey_step", "title"],
         "additionalProperties": false,
         "properties": {
-          "journey_step": { "type": "integer", "minimum": 1 },
+          "journey_step": { "type": ["integer", "string"], "minimum": 1 },
           "title": { "type": "string" },
           "story": { "type": "string" },
+          "branch": { "type": "string" },
           "actions": { "type": "array", "items": { "$ref": "#/$defs/action" } },
           "assertions": { "type": "array", "items": { "$ref": "#/$defs/assertion" } },
           "$conformance": { "$ref": "#/$defs/conformance" },

--- a/schemas/v1/lifecycle.schema.json
+++ b/schemas/v1/lifecycle.schema.json
@@ -11,6 +11,11 @@
     "type": { "const": "model" },
     "entity": { "type": "string", "minLength": 1 },
     "description": { "type": "string" },
+    "shape": {
+      "description": "Declarative lifecycle shape (#39). Selects which validator rule set applies. Default is `bounded` for back-compat.",
+      "enum": ["bounded", "unbounded", "absorbing", "cyclic"],
+      "default": "bounded"
+    },
     "sources": {
       "type": "object",
       "additionalProperties": false,

--- a/tests/schemas/shapes.test.js
+++ b/tests/schemas/shapes.test.js
@@ -1,0 +1,162 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const os = require('node:os');
+const fs = require('node:fs');
+const path = require('node:path');
+const yaml = require('js-yaml');
+const { execFileSync } = require('node:child_process');
+
+const { getValidator, loadIndex } = require('../../tools/lib/schema-loader');
+
+const REPO_ROOT = path.join(__dirname, '..', '..');
+const VALIDATE_MODELS = path.join(REPO_ROOT, 'tools', 'validate-models.js');
+const VALIDATE_JM = path.join(REPO_ROOT, 'tools', 'validate-journey-maps.js');
+
+function runJson(script, specsDir) {
+  const out = execFileSync(process.execPath, [script, specsDir, '--json'], {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+  });
+  return JSON.parse(out);
+}
+
+function writeYaml(filePath, data) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, yaml.dump(data));
+}
+
+test('schema registry version is bumped to 1.3.x or later', () => {
+  const index = loadIndex();
+  const [maj, min] = index.version.split('.').map(Number);
+  assert.equal(maj, 1);
+  assert.ok(min >= 3, `expected minor >= 3 for the declarative-shapes bump, got ${index.version}`);
+});
+
+test('lifecycle schema accepts shape: unbounded with no terminal state', () => {
+  const data = {
+    id: 'truth-file-lifecycle',
+    type: 'model',
+    entity: 'TruthFile',
+    shape: 'unbounded',
+    initial_state: 'draft',
+    states: {
+      draft: { description: 'in progress' },
+      active: { description: 'live' },
+    },
+  };
+  const result = getValidator('lifecycle')(data);
+  assert.ok(result.valid, `expected valid, got: ${JSON.stringify(result.errors)}`);
+});
+
+test('lifecycle validator emits no terminal-state warning under shape: unbounded', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'idd-shape-'));
+  const specs = path.join(tmp, 'specs');
+  writeYaml(path.join(specs, 'models', 'truth-file.lifecycle.yaml'), {
+    id: 'truth-file-lifecycle',
+    type: 'model',
+    entity: 'TruthFile',
+    shape: 'unbounded',
+    initial_state: 'active',
+    states: { active: { description: 'live' } },
+  });
+  const result = runJson(VALIDATE_MODELS, specs);
+  assert.equal(result.errors.length, 0, `errors: ${result.errors.join('\n')}`);
+  assert.ok(
+    !result.warnings.some((w) => w.toLowerCase().includes('terminal state')),
+    `expected no terminal-state warning, got: ${result.warnings.join('\n')}`,
+  );
+});
+
+test('lifecycle validator still warns about missing terminal under shape: bounded (default)', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'idd-shape-'));
+  const specs = path.join(tmp, 'specs');
+  writeYaml(path.join(specs, 'models', 'order.lifecycle.yaml'), {
+    id: 'order-lifecycle',
+    type: 'model',
+    entity: 'Order',
+    initial_state: 'pending',
+    states: { pending: { description: 'wip' } },
+  });
+  const result = runJson(VALIDATE_MODELS, specs);
+  assert.ok(
+    result.warnings.some((w) => w.toLowerCase().includes('terminal state')),
+    `expected terminal-state warning under default shape, got: ${result.warnings.join('\n')}`,
+  );
+});
+
+test('journey-map schema accepts shape: branching with duplicate journey_step + branch', () => {
+  const data = {
+    id: 'sign-in',
+    type: 'journey-map',
+    journey: 'sign-in',
+    shape: 'branching',
+    steps: {
+      'exchange-link': { journey_step: 3, title: 'Exchange link', branch: 'link-redeem' },
+      'exchange-code': { journey_step: 3, title: 'Exchange code', branch: 'code-redeem' },
+    },
+  };
+  const result = getValidator('journey-map')(data);
+  assert.ok(result.valid, `expected valid, got: ${JSON.stringify(result.errors)}`);
+});
+
+test('journey-map validator emits no non-sequential warning under shape: branching', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'idd-shape-'));
+  const specs = path.join(tmp, 'specs');
+  writeYaml(path.join(specs, 'journey-maps', 'sign-in.journey-map.yaml'), {
+    id: 'sign-in',
+    type: 'journey-map',
+    journey: 'sign-in',
+    shape: 'branching',
+    steps: {
+      'exchange-link': { journey_step: 3, title: 'Link', branch: 'link-redeem' },
+      'exchange-code': { journey_step: 3, title: 'Code', branch: 'code-redeem' },
+    },
+  });
+  const result = runJson(VALIDATE_JM, specs);
+  assert.equal(result.errors.length, 0, `errors: ${result.errors.join('\n')}`);
+  assert.ok(
+    !result.warnings.some((w) => w.toLowerCase().includes('non-sequential')),
+    `expected no non-sequential warning, got: ${result.warnings.join('\n')}`,
+  );
+  assert.ok(
+    result.info.some((i) => i.includes('fans out')),
+    `expected fan-out info, got: ${result.info.join('\n')}`,
+  );
+});
+
+test('journey-map validator warns when shape: branching but step missing branch key', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'idd-shape-'));
+  const specs = path.join(tmp, 'specs');
+  writeYaml(path.join(specs, 'journey-maps', 'auth.journey-map.yaml'), {
+    id: 'auth',
+    type: 'journey-map',
+    journey: 'auth',
+    shape: 'branching',
+    steps: {
+      'exchange-link': { journey_step: 3, title: 'Link', branch: 'link' },
+      'exchange-code': { journey_step: 3, title: 'Code' }, // missing branch
+    },
+  });
+  const result = runJson(VALIDATE_JM, specs);
+  assert.ok(
+    result.warnings.some((w) => w.includes('missing a `branch:`') || w.includes("missing a `branch:` key")),
+    `expected branch-missing warning, got: ${result.warnings.join('\n')}`,
+  );
+});
+
+test('journey-map shape rejects unknown shape value', () => {
+  const result = getValidator('journey-map')({
+    id: 'x', type: 'journey-map', journey: 'x', shape: 'mystery',
+  });
+  assert.ok(!result.valid);
+});
+
+test('lifecycle shape rejects unknown shape value', () => {
+  const result = getValidator('lifecycle')({
+    id: 'x', type: 'model', entity: 'X', shape: 'mystery',
+    initial_state: 's', states: { s: {} },
+  });
+  assert.ok(!result.valid);
+});

--- a/tools/validate-journey-maps.js
+++ b/tools/validate-journey-maps.js
@@ -90,6 +90,9 @@ function validateLegacyStepModel(map, errors, warnings, info) {
     return;
   }
 
+  // Shape selects step-ordering rules (#39). Default is `sequential` for back-compat.
+  const shape = typeof map.shape === 'string' ? map.shape : 'sequential';
+  const stepsByNumber = new Map();
   let lastStepNumber = 0;
 
   for (const [stepId, step] of Object.entries(map.steps)) {
@@ -104,10 +107,23 @@ function validateLegacyStepModel(map, errors, warnings, info) {
 
     if (!step.journey_step) {
       errors.push(`Step "${stepId}" missing journey_step number`);
-    } else if (step.journey_step <= lastStepNumber) {
-      warnings.push(`Step "${stepId}" has non-sequential journey_step (${step.journey_step} after ${lastStepNumber})`);
     } else {
-      lastStepNumber = step.journey_step;
+      const num = step.journey_step;
+      if (shape === 'sequential') {
+        if (typeof num === 'number' && num <= lastStepNumber) {
+          warnings.push(`Step "${stepId}" has non-sequential journey_step (${num} after ${lastStepNumber}). Declare \`shape: branching\` or \`shape: hierarchical\` if the order is intentional.`);
+        } else if (typeof num === 'number') {
+          lastStepNumber = num;
+        }
+      } else if (shape === 'branching') {
+        if (!step.branch) {
+          warnings.push(`Step "${stepId}" under shape:branching is missing a \`branch:\` key`);
+        }
+        const group = stepsByNumber.get(num) || [];
+        group.push({ stepId, branch: step.branch });
+        stepsByNumber.set(num, group);
+      }
+      // shape:hierarchical accepts any journey_step format (e.g., "3a", "3b")
     }
 
     if (!step.title) {
@@ -159,6 +175,19 @@ function validateLegacyStepModel(map, errors, warnings, info) {
         if (assertion.selector && !String(assertion.selector).includes('data-testid')) {
           warnings.push(`Step "${stepId}" assertion selector doesn't use data-testid: ${assertion.selector}`);
         }
+      }
+    }
+  }
+
+  if (shape === 'branching') {
+    for (const [num, group] of stepsByNumber.entries()) {
+      if (group.length < 2) continue;
+      const branches = group.map((g) => g.branch).filter(Boolean);
+      const uniqueBranches = new Set(branches);
+      if (uniqueBranches.size !== branches.length) {
+        warnings.push(`shape:branching — journey_step ${num} has steps sharing the same \`branch:\` value (${[...group].map((g) => `${g.stepId}/${g.branch || '(none)'}`).join(', ')})`);
+      } else {
+        info.push(`shape:branching — journey_step ${num} fans out across branches: ${branches.join(', ')}`);
       }
     }
   }

--- a/tools/validate-models.js
+++ b/tools/validate-models.js
@@ -392,9 +392,22 @@ function validateLifecycle(model, errors, warnings, info = []) {
     errors.push(`Initial state "${model.initial_state}" not found in states`);
   }
 
+  const shape = typeof model.shape === 'string' ? model.shape : 'bounded';
   const hasTerminal = Object.values(model.states).some((state) => state && state.terminal === true);
-  if (!hasTerminal) {
-    warnings.push('Lifecycle should have at least one terminal state');
+
+  // Shape selects which rule applies (#39).
+  //   bounded   — at least one terminal state required (default)
+  //   absorbing — at least one terminal state required
+  //   unbounded — no terminal needed (Customer, TruthFile, …)
+  //   cyclic    — no terminal needed; transitions may return to initial
+  if (shape === 'bounded' || shape === 'absorbing') {
+    if (!hasTerminal) {
+      warnings.push(`Lifecycle (shape:${shape}) should have at least one terminal state`);
+    }
+  } else if (shape === 'unbounded' || shape === 'cyclic') {
+    if (hasTerminal) {
+      info.push(`Lifecycle declared shape:${shape} but has a terminal state — that is allowed; the terminal-state requirement is only enforced for bounded/absorbing shapes`);
+    }
   }
 
   if (model.transitions && typeof model.transitions === 'object') {


### PR DESCRIPTION
Closes #39.

## Summary

Two artifact kinds previously had a fixed grammar baked into the validator — lifecycles required a terminal state, journey maps required strictly increasing `journey_step` numbers. Both are correct for the common case and misfire on legitimate alternatives:

- **Truth File** aggregates have no domain terminal — the canonical record exists for the customer's full lifetime. The previous workaround was to invent a fake `closed` state.
- **Magic-link redemption** legitimately puts `exchange-link` and `exchange-code` at the same journey_step. The previous validator flagged this as non-sequential.

v1.3 makes the shape *explicit*. The author declares the kind of artifact; the validator picks the matching rule set. The default for each is the previous rule, so existing files remain valid.

## Lifecycle shapes

| Shape | Rule | Use for |
|---|---|---|
| `bounded` (default) | ≥1 terminal state | Order, Audit, Signup |
| `absorbing` | ≥1 terminal state | Order (one reachable terminal) |
| `unbounded` | terminal NOT required | Customer, **TruthFile**, BusinessAccount |
| `cyclic` | terminal NOT required | Subscription, Membership |

## Journey-map shapes

| Shape | Rule | Use for |
|---|---|---|
| `sequential` (default) | strictly increasing `journey_step` | Linear flows |
| `branching` | duplicate `journey_step` allowed when each step has `branch:` | Magic-link redemption, retry alternates |
| `hierarchical` | string `journey_step` notation (`3a`, `3b`) accepted | Nested journeys |

Worked example for the wedge case:

\`\`\`yaml
shape: branching
steps:
  exchange-link:
    journey_step: 3
    branch: link-redeem
  exchange-code:
    journey_step: 3
    branch: code-redeem
\`\`\`

The validator emits an INFO summary of the fan-out and warns when a step under `shape: branching` is missing its `branch:` key.

## Why this inverts the relationship

The previous rules assumed one grammar and warned on everything else. The shape selector inverts that: the author tells the validator what kind of artifact this is, and the validator applies the matching rule set. The assumed grammar becomes a chosen grammar — the load-bearing move language-theoretically.

## Tests

\`tests/schemas/shapes.test.js\` (9 cases) covers:
- shape:unbounded silences the terminal-state warning end-to-end
- shape:bounded (default) still warns
- shape:branching accepts duplicate journey_step + branch
- shape:branching emits fan-out info
- Missing branch under shape:branching is warned
- Unknown shape values are schema-rejected
- Schema version is ≥ 1.3

Full suite: **52/52 passing** (\`npm test\`).

## What's next

The remaining issues under #24:
- #40 — reference closure as a capability-scope obligation (cross-document)
- #41 — bind model `enforced:` rules to concrete enforcement points (cross-document)

Both are imperative-checker work — neither needs further schema changes. The grammar surface is now closed at v1.3 for the #24 epic; #40 and #41 extend the cross-document checker layer that JSON Schema cannot express.

🤖 Generated with [Claude Code](https://claude.com/claude-code)