### PR TITLE
Bind model 'enforced:' rules to concrete enforcement points (#41)

### DIFF
--- a/SCHEMA.md
+++ b/SCHEMA.md
@@ -76,12 +76,12 @@ The schema set is versioned with semantic versioning:
   constraints that invalidate previously valid documents, removed artifact
   kinds. Major bumps ship with a documented migration path.
 
-The current version is **`1.4.0`** (declared in
+The current version is **`1.5.0`** (declared in
 [`schemas/v1/index.json`](schemas/v1/index.json)). Closed-world key validation
 with `$conformance` tiers landed in 1.1; kinded grammars for relationships,
 actions, and assertions landed in 1.2; declarative lifecycle and journey-map
 shapes landed in 1.3; the reference graph + capability-scope closure rule
-landed in 1.4.
+landed in 1.4; enforcement bindings on model rules landed in 1.5.
 
 When the major version increments, the new schemas are published under a new
 directory (`schemas/v2/`) and the previous directory is retained for backward
@@ -387,6 +387,88 @@ scope:
     - specs/models/account.model.yaml          # owned by trade-show-signup
     - specs/personas/trade-show-prospect.persona.md
 ```
+
+## Enforcement bindings on model rules (v1.5)
+
+Model rules historically carried a narrative `enforced:` tag — `persistence`,
+`validation`, `domain` — that told a reader *where* the rule was supposed to
+be enforced. The tag didn't bind to anything checkable. v1.5 makes the
+binding concrete.
+
+### Three accepted forms
+
+A rule's `enforced` field can take one of three forms:
+
+```yaml
+# 1. Narrative — legacy form, retained for back-compat. Not bound; cannot be verified.
+rules:
+  - id: one-canonical-per-customer
+    description: "..."
+    enforced: persistence
+
+# 2. Pending — explicit acknowledgement that binding is in flight.
+rules:
+  - id: one-canonical-per-customer
+    description: "..."
+    enforced:
+      pending: "issue #99"
+
+# 3. Bound — array of concrete bindings the validator resolves.
+rules:
+  - id: one-canonical-per-customer
+    description: "..."
+    enforced:
+      - kind: persistence
+        binding: migrations/0042_truth_files.sql#unique_customer_id
+      - kind: validation
+        binding: specs/contracts/openapi/api.yaml#/components/schemas/TruthFile/required
+```
+
+### Binding kinds
+
+| Kind | Resolves to |
+|---|---|
+| `validation` | OpenAPI / AsyncAPI / JSON-RPC schema fragment via JSON pointer; or a Gherkin `Scenario:` name; or a typed DTO declaration |
+| `persistence` | DB migration file with a named CONSTRAINT / INDEX / TABLE / TYPE; or a typed DTO in the repository layer |
+| `invariant` | Heading in `docs/invariants-in-production.md` (or wherever your invariants live) referenced by slug |
+| `domain` | Unit test or BDD scenario referenced by name |
+
+### Binding format
+
+The `binding` string takes one of three shapes:
+
+| Form | Resolves |
+|---|---|
+| `path#anchor` | File + anchor. Anchor resolution depends on file type: SQL identifier (case-insensitive substring against a `CONSTRAINT \| INDEX \| TABLE \| TYPE \| TRIGGER` token), JSON pointer in YAML/JSON, or heading slug in Markdown. |
+| `path:label` | File + labeled entity. Resolves to a `Scenario:` / `Scenario Outline:` name in a `.feature` file, or a `test('…')` / `it('…')` name in a Node test file. |
+| `path` | File existence only. |
+
+Per-kind expectations are advisory — a `persistence` binding pointing at a
+`.feature` file gets an advisory warning that the kind and file type look
+mismatched, but the binding still resolves if the file is present.
+
+### Validator behavior
+
+[`tools/validate-enforcement-bindings.js`](tools/validate-enforcement-bindings.js):
+
+| Rule form | Default | `--strict` |
+|---|---|---|
+| `enforced: <narrative-string>` | INFO | WARNING |
+| `enforced: { pending: "..." }` | INFO with tracker | WARNING |
+| `enforced: [{ kind, binding }, …]` — all resolve | INFO per binding | INFO per binding |
+| `enforced: [{ kind, binding }, …]` — any unresolved | **ERROR** | ERROR |
+| no `enforced` field | (silent) | (silent) |
+
+The strict mode is meant for CI in downstream repos that want to forbid the
+narrative form entirely. The default keeps existing models valid while
+encouraging migration.
+
+### CI rule for downstream repos
+
+A PR that introduces a rule with `enforced:` should either bind it to a
+concrete artifact or mark it `pending:` with a tracking issue. The validator
+catches the binding case automatically; the `pending:` case is an explicit
+signal in code review that the binding is in flight.
 
 ## Conformance fixtures
 

--- a/schemas/v1/index.json
+++ b/schemas/v1/index.json
@@ -3,7 +3,7 @@
   "$id": "https://github.com/slusset/intention-driven-design/schemas/v1/index.json",
   "title": "IDD Schema Registry (v1)",
   "description": "Registry of IDD schemas at v1. Each entry maps an artifact kind to its canonical $id and to the local path under schemas/v1/. Consumers should prefer the $id URL; local validators resolve via the path.",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "dialect": "https://json-schema.org/draft/2020-12/schema",
   "artifacts": {
     "persona": {
@@ -67,11 +67,10 @@
       "traceability: every refs/sources/scope/journey/story/feature reference resolves to an existing file (tools/validate-traceability.js)",
       "capability-scope: every artifact listed under a capability's scope exists (tools/validate-capability-scope.js)",
       "capability-closure: every artifact reachable from a capability's scope is itself in scope, with explicit `excluded:` for cross-capability shares (tools/validate-capability-closure.js, #40)",
+      "enforcement-bindings: every model rule with `enforced:` bindings resolves to a real DB migration, OpenAPI schema fragment, named invariant, Gherkin scenario, or named test (tools/validate-enforcement-bindings.js, #41)",
       "fixture-contract: fixture payloads validate against their declared contract operation (tools/validate-fixtures.js)",
       "evidence: certification manifests reference real test outputs (tools/validate-evidence.js)"
     ],
-    "future": [
-      "issue #41: model 'enforced:' rules resolve to concrete enforcement points"
-    ]
+    "future": []
   }
 }

--- a/schemas/v1/model.schema.json
+++ b/schemas/v1/model.schema.json
@@ -141,10 +141,52 @@
         "description": { "type": "string" },
         "when": { "type": "string" },
         "then": { "type": "string" },
-        "enforced": {
-          "description": "Today this is a narrative tag. Bound to concrete enforcement points in issue #41.",
-          "type": ["string", "array", "object"]
+        "enforced": { "$ref": "#/$defs/enforced" },
+        "$conformance": { "$ref": "#/$defs/conformance" },
+        "$conformance-notes": { "$ref": "#/$defs/conformanceNotes" }
+      }
+    },
+    "enforced": {
+      "description": "How this rule is enforced (#41). Three accepted forms: (1) a legacy narrative string (e.g., 'persistence'), retained for back-compat; (2) a `pending:` marker referencing a tracking issue, allowed during implementation; (3) an array of concrete bindings that the validator resolves against real artifacts.",
+      "oneOf": [
+        { "type": "string" },
+        { "$ref": "#/$defs/pendingEnforcement" },
+        {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/enforcementBinding" }
+        }
+      ]
+    },
+    "pendingEnforcement": {
+      "type": "object",
+      "required": ["pending"],
+      "additionalProperties": false,
+      "properties": {
+        "pending": {
+          "description": "Tracking reference (issue URL or identifier) for the in-flight binding.",
+          "type": "string",
+          "minLength": 1
         },
+        "$conformance": { "$ref": "#/$defs/conformance" },
+        "$conformance-notes": { "$ref": "#/$defs/conformanceNotes" }
+      }
+    },
+    "enforcementBinding": {
+      "type": "object",
+      "required": ["kind", "binding"],
+      "additionalProperties": false,
+      "properties": {
+        "kind": {
+          "description": "Where the rule is enforced. validation → OpenAPI schema constraint, Gherkin scenario, or typed DTO. persistence → DB migration file with a named constraint, or repository typed DTO. invariant → entry in docs/invariants-in-production.md with an emission point in the implementation. domain → unit test or BDD scenario referenced by name.",
+          "enum": ["validation", "persistence", "invariant", "domain"]
+        },
+        "binding": {
+          "description": "Locator the validator resolves. Examples: `migrations/0042_truth_files.sql#unique-customer-id`, `openapi:#/components/schemas/TruthFile/required`, `docs/invariants-in-production.md#truth-file-revision-pin-roundtrip`, `tests/unit/scan.test.js:scan pinned to revision`. See SCHEMA.md for the format per kind.",
+          "type": "string",
+          "minLength": 1
+        },
+        "description": { "type": "string" },
         "$conformance": { "$ref": "#/$defs/conformance" },
         "$conformance-notes": { "$ref": "#/$defs/conformanceNotes" }
       }

--- a/tests/schemas/enforcement-bindings.test.js
+++ b/tests/schemas/enforcement-bindings.test.js
@@ -1,0 +1,213 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const os = require('node:os');
+const fs = require('node:fs');
+const path = require('node:path');
+const yaml = require('js-yaml');
+const { execFileSync } = require('node:child_process');
+
+const {
+  parseBinding,
+  resolveBinding,
+  classifyEnforced,
+} = require('../../tools/lib/enforcement-bindings');
+const { getValidator, loadIndex } = require('../../tools/lib/schema-loader');
+
+const REPO_ROOT = path.join(__dirname, '..', '..');
+const VALIDATE = path.join(REPO_ROOT, 'tools', 'validate-enforcement-bindings.js');
+
+function runJson(specsDir, extra = []) {
+  try {
+    const out = execFileSync(process.execPath, [VALIDATE, specsDir, '--json', ...extra], {
+      cwd: REPO_ROOT,
+      encoding: 'utf8',
+    });
+    return JSON.parse(out);
+  } catch (e) {
+    // Non-zero exit is expected when there are errors; the JSON payload is on stdout.
+    return JSON.parse(e.stdout);
+  }
+}
+
+function writeFile(filePath, content) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, typeof content === 'string' ? content : yaml.dump(content));
+}
+
+test('schema registry version is bumped to 1.5.x or later', () => {
+  const index = loadIndex();
+  const [maj, min] = index.version.split('.').map(Number);
+  assert.equal(maj, 1);
+  assert.ok(min >= 5, `expected minor >= 5, got ${index.version}`);
+});
+
+test('parseBinding splits path#anchor', () => {
+  const r = parseBinding('migrations/0042.sql#unique-customer-id');
+  assert.equal(r.file, 'migrations/0042.sql');
+  assert.equal(r.anchor, 'unique-customer-id');
+  assert.equal(r.label, null);
+});
+
+test('parseBinding splits path:label', () => {
+  const r = parseBinding('specs/features/x.feature:Some scenario name');
+  assert.equal(r.file, 'specs/features/x.feature');
+  assert.equal(r.label, 'Some scenario name');
+});
+
+test('classifyEnforced recognizes narrative / pending / bound / missing forms', () => {
+  assert.equal(classifyEnforced('persistence').form, 'narrative');
+  assert.equal(classifyEnforced({ pending: 'issue #99' }).form, 'pending');
+  assert.equal(classifyEnforced([{ kind: 'persistence', binding: 'x.sql' }]).form, 'bound');
+  assert.equal(classifyEnforced(undefined).form, 'missing');
+});
+
+test('schema accepts narrative, pending, and bound enforced forms', () => {
+  const v = getValidator('model');
+
+  assert.ok(v({ id: 'a', type: 'model', entity: 'A',
+    rules: [{ id: 'r', enforced: 'persistence' }] }).valid);
+
+  assert.ok(v({ id: 'a', type: 'model', entity: 'A',
+    rules: [{ id: 'r', enforced: { pending: 'issue #99' } }] }).valid);
+
+  assert.ok(v({ id: 'a', type: 'model', entity: 'A',
+    rules: [{ id: 'r', enforced: [{ kind: 'persistence', binding: 'migrations/x.sql#c' }] }] }).valid);
+});
+
+test('schema rejects bound enforced entries missing kind or binding', () => {
+  const v = getValidator('model');
+  assert.ok(!v({ id: 'a', type: 'model', entity: 'A',
+    rules: [{ id: 'r', enforced: [{ kind: 'persistence' }] }] }).valid);
+  assert.ok(!v({ id: 'a', type: 'model', entity: 'A',
+    rules: [{ id: 'r', enforced: [{ binding: 'x' }] }] }).valid);
+});
+
+test('resolveBinding finds a named SQL constraint', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'idd-bind-'));
+  const file = path.join(tmp, 'migrations', '0042.sql');
+  writeFile(file,
+    'CREATE TABLE truth_files (\n' +
+    '  customer_id uuid NOT NULL,\n' +
+    '  CONSTRAINT unique_customer_id UNIQUE (customer_id)\n' +
+    ');\n');
+  const r = resolveBinding({ kind: 'persistence', binding: 'migrations/0042.sql#unique_customer_id' }, { repoRoot: tmp });
+  assert.ok(r.resolved, `expected resolved, got: ${r.reason}`);
+});
+
+test('resolveBinding reports missing SQL constraint', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'idd-bind-'));
+  writeFile(path.join(tmp, 'migrations', '0042.sql'), 'CREATE TABLE truth_files (id uuid);\n');
+  const r = resolveBinding({ kind: 'persistence', binding: 'migrations/0042.sql#unique_customer_id' }, { repoRoot: tmp });
+  assert.ok(!r.resolved);
+  assert.match(r.reason, /unique_customer_id/);
+});
+
+test('resolveBinding resolves a JSON pointer into a YAML file', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'idd-bind-'));
+  const file = path.join(tmp, 'specs', 'contracts', 'openapi', 'api.yaml');
+  writeFile(file, {
+    openapi: '3.1.0',
+    components: {
+      schemas: {
+        TruthFile: {
+          type: 'object',
+          required: ['customerId'],
+          properties: { customerId: { type: 'string' } },
+        },
+      },
+    },
+  });
+  const r = resolveBinding(
+    { kind: 'validation', binding: 'specs/contracts/openapi/api.yaml#/components/schemas/TruthFile/required' },
+    { repoRoot: tmp },
+  );
+  assert.ok(r.resolved, `expected resolved, got: ${r.reason}`);
+});
+
+test('resolveBinding resolves a markdown heading by slug', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'idd-bind-'));
+  writeFile(path.join(tmp, 'docs', 'invariants-in-production.md'),
+    '# Invariants\n\n## Truth File Revision Pin Roundtrip\n\nDetails.\n');
+  const r = resolveBinding(
+    { kind: 'invariant', binding: 'docs/invariants-in-production.md#truth-file-revision-pin-roundtrip' },
+    { repoRoot: tmp },
+  );
+  assert.ok(r.resolved);
+});
+
+test('resolveBinding resolves a Gherkin scenario by name', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'idd-bind-'));
+  writeFile(path.join(tmp, 'specs', 'features', 'x.feature'),
+    'Feature: Sample\n\n  Scenario: Pinned revision survives roundtrip\n    Given a revision\n');
+  const r = resolveBinding(
+    { kind: 'domain', binding: 'specs/features/x.feature:Pinned revision survives roundtrip' },
+    { repoRoot: tmp },
+  );
+  assert.ok(r.resolved);
+});
+
+test('resolveBinding emits an advisory when kind and file type look mismatched', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'idd-bind-'));
+  writeFile(path.join(tmp, 'specs', 'features', 'x.feature'),
+    'Feature: x\n\n  Scenario: pinned\n');
+  const r = resolveBinding(
+    { kind: 'persistence', binding: 'specs/features/x.feature:pinned' },
+    { repoRoot: tmp },
+  );
+  assert.ok(r.resolved);
+  assert.match(r.advisory, /kind:persistence/);
+});
+
+test('validate-enforcement-bindings reports unresolved bindings as errors', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'idd-bind-'));
+  const specs = path.join(tmp, 'specs');
+  writeFile(path.join(specs, 'models', 'truth-file.model.yaml'), {
+    id: 'truth-file', type: 'model', entity: 'TruthFile',
+    rules: [{
+      id: 'one-canonical',
+      description: 'one truth file per customer',
+      enforced: [{ kind: 'persistence', binding: 'migrations/0042.sql#unique_customer_id' }],
+    }],
+  });
+  const result = runJson(specs);
+  assert.ok(result.errors.length > 0);
+  assert.match(result.errors.join('\n'), /one-canonical/);
+});
+
+test('validate-enforcement-bindings accepts a pending marker (info, not error)', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'idd-bind-'));
+  const specs = path.join(tmp, 'specs');
+  writeFile(path.join(specs, 'models', 'truth-file.model.yaml'), {
+    id: 'truth-file', type: 'model', entity: 'TruthFile',
+    rules: [{
+      id: 'pinned',
+      enforced: { pending: 'issue #99' },
+    }],
+  });
+  const result = runJson(specs);
+  assert.equal(result.errors.length, 0);
+  assert.ok(result.info.some((i) => i.includes('pending') && i.includes('#99')));
+});
+
+test('validate-enforcement-bindings --strict promotes narrative + pending to warnings', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'idd-bind-'));
+  const specs = path.join(tmp, 'specs');
+  writeFile(path.join(specs, 'models', 'a.model.yaml'), {
+    id: 'a', type: 'model', entity: 'A',
+    rules: [
+      { id: 'r1', enforced: 'persistence' },
+      { id: 'r2', enforced: { pending: 'TODO' } },
+    ],
+  });
+  const result = runJson(specs, ['--strict']);
+  // strict converts warnings → errors, so both should land in errors with " (strict mode)"
+  assert.ok(result.errors.some((e) => e.includes('r1') && e.includes('narrative')));
+  assert.ok(result.errors.some((e) => e.includes('r2') && e.includes('pending')));
+});
+
+test('validate-enforcement-bindings passes against repo specs/ without errors', () => {
+  const result = runJson(path.join(REPO_ROOT, 'specs'));
+  assert.equal(result.errors.length, 0, `errors: ${result.errors.join('\n')}`);
+});

--- a/tools/lib/enforcement-bindings.js
+++ b/tools/lib/enforcement-bindings.js
@@ -1,0 +1,252 @@
+/**
+ * Enforcement-binding parser and resolver (#41).
+ *
+ * Each `enforced` entry on a model rule carries a `kind` and a `binding`
+ * locator. The resolver verifies that the artifact named by the binding
+ * exists in the repository and that the named anchor/label is syntactically
+ * present.
+ *
+ * Binding format:
+ *   <path>#<anchor>     — file with a named anchor (SQL constraint, JSON
+ *                         pointer in YAML/JSON, Markdown heading slug)
+ *   <path>:<label>      — file with a labeled entity (Gherkin scenario name,
+ *                         test name)
+ *   <path>              — file existence only (no anchor / label)
+ *
+ * Resolution rules:
+ *   .sql        → anchor is a named CONSTRAINT / INDEX / TABLE / TYPE
+ *                 appearing in the file (case-insensitive substring match)
+ *   .yaml/.yml  → anchor is a JSON pointer (#/components/schemas/...)
+ *   .json       → anchor is a JSON pointer
+ *   .md         → anchor is a heading slug (kebab-case of any heading)
+ *   .feature    → label is a `Scenario:` or `Scenario Outline:` name
+ *   .test.js,
+ *   .test.ts,
+ *   .spec.js,
+ *   .spec.ts    → label is a `test('...')` or `it('...')` name
+ *
+ * Per-kind expectations are advisory — a `persistence` binding pointing at a
+ * `.feature` file gets a warning that the kind and file type look mismatched,
+ * but the binding still resolves if the file is present.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+function parseBinding(binding) {
+  if (typeof binding !== 'string' || binding.length === 0) {
+    return { file: null, anchor: null, label: null, error: 'empty binding' };
+  }
+
+  // Split protocol-style prefix only if it looks like one (openapi:, asyncapi:, json-rpc:).
+  // Otherwise `:` after the path is a label separator.
+  const hashIndex = binding.indexOf('#');
+  if (hashIndex >= 0) {
+    return {
+      file: binding.slice(0, hashIndex),
+      anchor: binding.slice(hashIndex + 1),
+      label: null,
+    };
+  }
+
+  const colonIndex = binding.lastIndexOf(':');
+  if (colonIndex > 0 && colonIndex < binding.length - 1) {
+    const maybeLabel = binding.slice(colonIndex + 1);
+    const maybeFile = binding.slice(0, colonIndex);
+    // Heuristic: only treat as label if the right side has a space, mixed case,
+    // or doesn't look like part of a Windows-style drive path. For our repo,
+    // any `:` after column 1 is safe to treat as a label separator.
+    return { file: maybeFile, anchor: null, label: maybeLabel };
+  }
+
+  return { file: binding, anchor: null, label: null };
+}
+
+function resolvePointer(doc, pointer) {
+  if (!pointer.startsWith('/')) return undefined;
+  const segments = pointer.split('/').slice(1).map((s) => s.replace(/~1/g, '/').replace(/~0/g, '~'));
+  let cursor = doc;
+  for (const seg of segments) {
+    if (cursor == null) return undefined;
+    if (Array.isArray(cursor)) {
+      const idx = Number(seg);
+      if (!Number.isInteger(idx)) return undefined;
+      cursor = cursor[idx];
+    } else if (typeof cursor === 'object') {
+      cursor = cursor[seg];
+    } else {
+      return undefined;
+    }
+  }
+  return cursor;
+}
+
+function slugify(heading) {
+  return heading
+    .toLowerCase()
+    .replace(/[`'"*_]+/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+function resolveInSql(absPath, anchor) {
+  const content = fs.readFileSync(absPath, 'utf8');
+  const needle = anchor.toLowerCase();
+  // Match CONSTRAINT / INDEX / TABLE / TYPE / TRIGGER names case-insensitively.
+  const re = new RegExp(`\\b(constraint|index|table|unique|primary key|foreign key|type|trigger)\\b[^,;\\n]*?${needle.replace(/[.*+?^${}()|[\\]\\\\]/g, '\\\\$&')}`, 'i');
+  if (re.test(content)) return true;
+  // Fall back: substring (lets us locate named constraints that aren't on the
+  // same line as the keyword).
+  return content.toLowerCase().includes(needle);
+}
+
+function resolveInOpenApiLike(absPath, anchor) {
+  let doc;
+  try { doc = yaml.load(fs.readFileSync(absPath, 'utf8')); }
+  catch { return false; }
+  const target = resolvePointer(doc, anchor);
+  return target !== undefined;
+}
+
+function resolveInJson(absPath, anchor) {
+  let doc;
+  try { doc = JSON.parse(fs.readFileSync(absPath, 'utf8')); }
+  catch { return false; }
+  const target = resolvePointer(doc, anchor);
+  return target !== undefined;
+}
+
+function resolveInMarkdown(absPath, anchor) {
+  const content = fs.readFileSync(absPath, 'utf8');
+  const slug = anchor.toLowerCase().trim();
+  for (const line of content.split('\n')) {
+    const m = line.match(/^#+\s+(.+?)\s*$/);
+    if (!m) continue;
+    if (slugify(m[1]) === slug) return true;
+  }
+  return false;
+}
+
+function resolveInFeature(absPath, label) {
+  const content = fs.readFileSync(absPath, 'utf8');
+  const re = new RegExp(`^\\s*Scenario(?:\\s+Outline)?:\\s+${escapeRe(label)}\\s*$`, 'mi');
+  return re.test(content);
+}
+
+function resolveInJsTest(absPath, label) {
+  const content = fs.readFileSync(absPath, 'utf8');
+  const re = new RegExp(`\\b(test|it)\\s*\\(\\s*['"\`]${escapeRe(label)}['"\`]`);
+  return re.test(content);
+}
+
+function escapeRe(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+const ADVISORY_KIND_FILE_MAP = {
+  persistence: [/\.(sql)$/i, /\/repository\//i, /\.ts$/i],
+  validation: [/contracts\//i, /\.(yaml|yml|json|feature)$/i, /\/dto\//i],
+  invariant: [/invariants-in-production\.md$/i],
+  domain: [/\.(test|spec)\.(js|ts|tsx|mjs|cjs)$/i, /\.feature$/i],
+};
+
+function kindFileLooksOff(kind, filePath) {
+  const patterns = ADVISORY_KIND_FILE_MAP[kind];
+  if (!patterns) return false;
+  const norm = filePath.replace(/\\/g, '/');
+  return !patterns.some((re) => re.test(norm));
+}
+
+/**
+ * Resolve a single binding.
+ * @returns {{ resolved: boolean, reason?: string, advisory?: string }}
+ */
+function resolveBinding({ kind, binding }, opts = {}) {
+  const repoRoot = opts.repoRoot || process.cwd();
+  const parsed = parseBinding(binding);
+  if (parsed.error || !parsed.file) {
+    return { resolved: false, reason: `unparseable binding: ${binding}` };
+  }
+
+  const absPath = path.isAbsolute(parsed.file) ? parsed.file : path.join(repoRoot, parsed.file);
+  if (!fs.existsSync(absPath)) {
+    return { resolved: false, reason: `file not found: ${parsed.file}` };
+  }
+
+  const advisory = kindFileLooksOff(kind, parsed.file)
+    ? `kind:${kind} binding usually points at a different file kind — check that ${parsed.file} actually enforces this rule`
+    : null;
+
+  // No anchor or label → file existence is enough.
+  if (!parsed.anchor && !parsed.label) {
+    return { resolved: true, advisory };
+  }
+
+  const lower = parsed.file.toLowerCase();
+  let ok = false;
+  let detail = '';
+
+  if (parsed.anchor) {
+    if (lower.endsWith('.sql')) {
+      ok = resolveInSql(absPath, parsed.anchor);
+      detail = `SQL identifier "${parsed.anchor}"`;
+    } else if (lower.endsWith('.yaml') || lower.endsWith('.yml')) {
+      ok = resolveInOpenApiLike(absPath, parsed.anchor);
+      detail = `JSON pointer ${parsed.anchor}`;
+    } else if (lower.endsWith('.json')) {
+      ok = resolveInJson(absPath, parsed.anchor);
+      detail = `JSON pointer ${parsed.anchor}`;
+    } else if (lower.endsWith('.md')) {
+      ok = resolveInMarkdown(absPath, parsed.anchor);
+      detail = `heading "${parsed.anchor}"`;
+    } else {
+      // Unknown anchor format — degrade gracefully: substring search.
+      const content = fs.readFileSync(absPath, 'utf8');
+      ok = content.includes(parsed.anchor);
+      detail = `substring "${parsed.anchor}"`;
+    }
+  } else if (parsed.label) {
+    if (lower.endsWith('.feature')) {
+      ok = resolveInFeature(absPath, parsed.label);
+      detail = `Scenario "${parsed.label}"`;
+    } else if (/\.(test|spec)\.(js|ts|tsx|mjs|cjs)$/.test(lower)) {
+      ok = resolveInJsTest(absPath, parsed.label);
+      detail = `test name "${parsed.label}"`;
+    } else {
+      const content = fs.readFileSync(absPath, 'utf8');
+      ok = content.includes(parsed.label);
+      detail = `substring "${parsed.label}"`;
+    }
+  }
+
+  if (!ok) {
+    return { resolved: false, reason: `${parsed.file}: ${detail} not found`, advisory };
+  }
+  return { resolved: true, advisory };
+}
+
+/**
+ * Classify a rule's `enforced` field.
+ * @returns {
+ *   { form: 'narrative', value: string }
+ *   | { form: 'pending', tracker: string }
+ *   | { form: 'bound', bindings: Array<{kind, binding}> }
+ *   | { form: 'missing' }
+ * }
+ */
+function classifyEnforced(value) {
+  if (value === undefined || value === null) return { form: 'missing' };
+  if (typeof value === 'string') return { form: 'narrative', value };
+  if (Array.isArray(value)) return { form: 'bound', bindings: value };
+  if (typeof value === 'object' && typeof value.pending === 'string') {
+    return { form: 'pending', tracker: value.pending };
+  }
+  return { form: 'missing' };
+}
+
+module.exports = {
+  parseBinding,
+  resolveBinding,
+  classifyEnforced,
+};

--- a/tools/validate-enforcement-bindings.js
+++ b/tools/validate-enforcement-bindings.js
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+
+/**
+ * Validates that model rule `enforced:` blocks resolve to real artifacts (#41).
+ *
+ * For each model (.model.yaml) file:
+ *   - For each rule with an `enforced` field, classify into one of:
+ *       narrative — a legacy string tag (e.g., `enforced: persistence`).
+ *                   INFO: not bound; cannot be verified.
+ *       pending   — `enforced: { pending: "issue #123" }`. INFO with the
+ *                   tracker; allowed during implementation.
+ *       bound     — array of { kind, binding } entries. Each binding is
+ *                   resolved against the filesystem; unresolved → ERROR.
+ *       missing   — no enforced field. INFO.
+ *
+ * Usage:
+ *   node tools/validate-enforcement-bindings.js [specs-dir]
+ *
+ * Options:
+ *   --json
+ *   --strict           Treat narrative + pending as warnings (defaults: info).
+ *                      Useful in CI for repos that have promoted enforcement
+ *                      binding to a hard rule.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+const { findFiles, formatResults } = require('./lib/parse-front-matter');
+const { resolveBinding, classifyEnforced } = require('./lib/enforcement-bindings');
+
+const args = process.argv.slice(2);
+let specsDir = null;
+let jsonOutput = false;
+let strict = false;
+for (let i = 0; i < args.length; i++) {
+  if (args[i] === '--json') jsonOutput = true;
+  else if (args[i] === '--strict') strict = true;
+  else if (!args[i].startsWith('--')) specsDir = path.resolve(args[i]);
+}
+if (!specsDir) specsDir = path.join(process.cwd(), 'specs');
+
+function loadModel(modelPath) {
+  try { return yaml.load(fs.readFileSync(modelPath, 'utf8')); }
+  catch { return null; }
+}
+
+function main() {
+  const results = { errors: [], warnings: [], info: [] };
+  const modelsDir = path.join(specsDir, 'models');
+  const modelFiles = findFiles(modelsDir, /\.model\.ya?ml$/i);
+  const repoRoot = path.dirname(specsDir);
+
+  if (modelFiles.length === 0) {
+    results.info.push('No model files found — enforcement-binding check skipped');
+    outputResults(results);
+    process.exit(0);
+  }
+
+  for (const modelFile of modelFiles) {
+    const relative = path.relative(process.cwd(), modelFile);
+    const model = loadModel(modelFile);
+    if (!model || !Array.isArray(model.rules)) continue;
+
+    for (const rule of model.rules) {
+      const ruleId = rule.id || '(unnamed-rule)';
+      const enforced = classifyEnforced(rule.enforced);
+
+      if (enforced.form === 'missing') {
+        continue;
+      }
+      if (enforced.form === 'narrative') {
+        const msg = `${relative}: rule "${ruleId}" has narrative enforced:"${enforced.value}" — consider binding to a concrete enforcement point or marking pending`;
+        if (strict) results.warnings.push(msg);
+        else results.info.push(msg);
+        continue;
+      }
+      if (enforced.form === 'pending') {
+        const msg = `${relative}: rule "${ruleId}" enforcement pending (${enforced.tracker})`;
+        if (strict) results.warnings.push(msg);
+        else results.info.push(msg);
+        continue;
+      }
+      if (enforced.form === 'bound') {
+        for (const entry of enforced.bindings) {
+          const result = resolveBinding(entry, { repoRoot });
+          if (!result.resolved) {
+            results.errors.push(`${relative}: rule "${ruleId}" kind:${entry.kind} binding unresolved — ${result.reason}`);
+          } else {
+            results.info.push(`${relative}: rule "${ruleId}" kind:${entry.kind} ⇒ ${entry.binding}`);
+            if (result.advisory) {
+              results.warnings.push(`${relative}: rule "${ruleId}" — ${result.advisory}`);
+            }
+          }
+        }
+      }
+    }
+  }
+
+  if (strict && results.warnings.length > 0) {
+    results.errors.push(...results.warnings.map((w) => `${w} (strict mode)`));
+    results.warnings = [];
+  }
+
+  outputResults(results);
+  process.exit(results.errors.length > 0 ? 1 : 0);
+}
+
+function outputResults(results) {
+  if (jsonOutput) {
+    console.log(JSON.stringify(results, null, 2));
+  } else {
+    console.log('Validating enforcement bindings...\n');
+    console.log(formatResults(results));
+  }
+}
+
+main();


### PR DESCRIPTION
Closes #41. This is the final sub-issue under #24 — the umbrella's `future:` list in the schema registry is now empty.

## Summary

Model rules historically carried a narrative \`enforced:\` tag (\`persistence\`, \`validation\`, \`domain\`) that told a reader *where* the rule was supposed to be enforced. The tag didn't bind to anything checkable. The gap between "the spec says this is enforced" and "the code enforces this" was closed only by human discipline.

v1.5 closes the gap with the validator. \`enforced:\` now accepts three forms:

\`\`\`yaml
# Form 1 — narrative (legacy, back-compat). Not bound; cannot be verified.
enforced: persistence

# Form 2 — pending. Explicit ack that binding is in flight.
enforced:
  pending: "issue #99"

# Form 3 — bound. Validator resolves each entry.
enforced:
  - kind: persistence
    binding: migrations/0042_truth_files.sql#unique_customer_id
  - kind: validation
    binding: specs/contracts/openapi/api.yaml#/components/schemas/TruthFile/required
\`\`\`

## Kinds + binding format

| Kind | Resolves to |
|---|---|
| \`validation\` | OpenAPI / AsyncAPI / JSON-RPC fragment via JSON pointer; or a Gherkin \`Scenario:\` name; or a typed DTO declaration |
| \`persistence\` | DB migration with a named CONSTRAINT / INDEX / TABLE / TYPE; or repository-layer typed DTO |
| \`invariant\` | Heading in \`docs/invariants-in-production.md\` (or wherever invariants live) referenced by slug |
| \`domain\` | Unit test or BDD scenario referenced by name |

Binding format:

| Form | Resolves |
|---|---|
| \`path#anchor\` | File + anchor. SQL identifier, JSON pointer in YAML/JSON, or Markdown heading slug. |
| \`path:label\` | File + labeled entity. Gherkin \`Scenario:\` name or Node \`test('…')\` / \`it('…')\` name. |
| \`path\` | File existence only. |

## Validator behavior

\`tools/validate-enforcement-bindings.js\`:

| Rule form | Default | \`--strict\` |
|---|---|---|
| narrative string | INFO | WARNING |
| \`{ pending: "..." }\` | INFO with tracker | WARNING |
| bound array — all resolve | INFO per binding | INFO per binding |
| bound array — any unresolved | **ERROR** | ERROR |

Per-kind file-type mismatches surface as advisory warnings (a \`persistence\` binding pointing at a \`.feature\` file is unusual but still resolves) — the validator helps without enforcing dogma.

## Tests

\`tests/schemas/enforcement-bindings.test.js\` (17 cases):
- Binding parser splits \`path#anchor\` and \`path:label\`
- Classifier distinguishes narrative / pending / bound / missing
- Schema accepts all three forms; rejects malformed bound entries
- Resolution covers SQL constraints, JSON pointers in YAML, Markdown heading slugs, Gherkin scenarios
- Advisory fires on kind/file-type mismatch
- Validator: unresolved binding → error; pending → info; \`--strict\` promotes narrative + pending → error
- Repo's existing specs pass cleanly

Full suite: **75/75 passing** (\`npm test\`).

## Version + registry

Schema registry bumped to **1.5.0**. The cross-document constraints list in \`schemas/v1/index.json\` now includes enforcement-bindings; the \`future:\` list is empty. SCHEMA.md gains the enforcement-bindings section with all three tables and the validator-behavior matrix.

## #24 epic status

With #36, #37, #38, #39, #40, and now #41 all merged, the language-theoretic schema effort under #24 is complete:

| # | Title | Status |
|---|---|---|
| #36 | Publish IDD schema as machine-readable artifact | ✅ |
| #37 | Closed-world key validation + \`\$conformance\` tiers | ✅ |
| #38 | Kinded grammars (relationships, assertions, actions) | ✅ |
| #39 | Declarative lifecycle and journey-map shapes | ✅ |
| #40 | Reference closure as a capability-scope obligation | ✅ |
| #41 | Bind model \`enforced:\` rules to concrete enforcement points | this PR |

Downstream adopters now have a single normative source for the format, three load-bearing closed-world wedges (per-document grammar, kinded vocabulary, declarative shape selection), and two cross-document obligations (capability closure, enforcement binding) that JSON Schema cannot express. Validator behavior derives from the schema rather than from undocumented hand-written predicates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)