### PR TITLE
Release v1.0.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "idd-skills",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "Intention-Driven Design methodology skills. Narrative-first development: personas, journeys, stories, domain models, behavior contracts, and e2e journey testing. Bundles validator scripts invoked via ${CLAUDE_PLUGIN_ROOT}.",
   "author": {
     "name": "Ted Slusser",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,37 +7,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
+## [1.0.0] - 2026-05-16
 
-- `.claude-plugin/marketplace.json` — local marketplace descriptor so the repo can be installed in Claude Code via `/plugin marketplace add` + `/plugin install idd-skills@idd`
-- `justfile` — wraps common local flows (`just install`, `just validate`, `just test`, `just install-skills`, lint tasks)
+The language-theoretic schema effort ([#24](https://github.com/slusset/intention-driven-design/issues/24)) lands as 1.0. The IDD specification format now has a single normative source, closed-world key validation, kinded vocabularies, declarative artifact shapes, and two cross-document obligations that JSON Schema cannot express. Schema registry at **v1.5.0**; toolkit and plugin promoted to **1.0.0**.
+
+### Added — schema effort ([#24](https://github.com/slusset/intention-driven-design/issues/24))
+
+- **`schemas/v1/`** — nine JSON Schemas (Draft 2020-12) under stable `$id` URLs at `github.com/slusset/intention-driven-design/schemas/v1/`, indexed by `schemas/v1/index.json`. One schema per artifact kind: persona, journey, story, feature, model, lifecycle, journey-map, capability, fixture. ([#43](https://github.com/slusset/intention-driven-design/pull/43))
+- **`tools/lib/schema-loader.js`** — centralized ajv loader with `getValidator(kind)` + `categorize()` for severity-based error reporting.
+- **`SCHEMA.md`** — entry point for downstream adopters: artifact set, dialect, version policy, extension model, kinded grammars, declarative shapes, reference graph, enforcement bindings, consumer integration (HTTP fetch / npm / yaml-language-server).
+- **Closed-world keys + `$conformance` tiers** — every enumerated object level rejects unknown properties. `$conformance: canonical | legacy-compatible | experimental` is reserved at every level. Unknown keys are warnings by default, demoted to info when tagged experimental. ([#44](https://github.com/slusset/intention-driven-design/pull/44))
+- **Kinded grammars** — relationships, actions, and assertions express a `kind` plus attributes. Legacy enum values remain valid as named combinations the validator expands. New kinds include `pointer` + `temporality: pinned`, `cookie`, `classification`, `tag`, `context`. The authoritative registry is `tools/lib/kinds.js`. ([#45](https://github.com/slusset/intention-driven-design/pull/45))
+- **Declarative shapes** — lifecycles declare `bounded | unbounded | absorbing | cyclic`; journey maps declare `sequential | branching | hierarchical`. The author tells the validator what kind of artifact this is; the validator applies the matching rule set. ([#46](https://github.com/slusset/intention-driven-design/pull/46))
+- **`tools/lib/reference-graph.js`** + **`tools/validate-capability-closure.js`** — cross-document validator that computes the transitive closure of artifacts reachable from a capability's scope and warns when something is reachable but not declared, or declared but unreferenced (narrative tier only). `scope.excluded` names cross-capability shares explicitly. ([#47](https://github.com/slusset/intention-driven-design/pull/47))
+- **`tools/lib/enforcement-bindings.js`** + **`tools/validate-enforcement-bindings.js`** — model rule `enforced:` fields now accept three forms: narrative string (legacy), `{ pending: "tracker" }` (in-flight), or array of `{ kind, binding }` (verifiable). Bindings resolve to real SQL constraints, OpenAPI fragments, Markdown invariant headings, Gherkin scenarios, or named tests. ([#48](https://github.com/slusset/intention-driven-design/pull/48))
+- **`tests/schemas/`** — 75 schema-effort tests covering conformance, closed-world, kinded grammars, shapes, closure, and enforcement bindings. `specs/` examples double as conformance fixtures auto-discovered by the suite.
+
+### Added — methodology
+
+- **Agent role extension** — `docs/idd/agent-role.md` defines a bounded execution contract for delegated and multi-agent work (responsibility, inputs, allowed decisions, outputs, handoff). Reusable template at `docs/idd/templates/agent-role-contract.yaml`. Integrated into `idd-workflow` and `pr-review` skills. ([#42](https://github.com/slusset/intention-driven-design/pull/42))
+- **Methodology change process** — `docs/idd/methodology-change-process.md` with explicit exploratory → provisional → canonical states and an improvement-proposal template. The same vocabulary now drives the schema's `$conformance` tiers. ([#42](https://github.com/slusset/intention-driven-design/pull/42))
+- **Self-evolving ecosystem note** — `docs/idd/self-evolving-ecosystem.md` describing the three-layer model (seed structure / runtime / adaptive substrate).
+
+### Added — packaging
+
+- `.claude-plugin/marketplace.json` — local marketplace descriptor so the repo can be installed in Claude Code via `/plugin marketplace add` + `/plugin install idd-skills@idd`.
+- `justfile` — wraps common local flows (`just install`, `just validate`, `just test`, `just install-skills`, lint tasks).
 
 ### Changed
 
-- Skills now invoke bundled validators via `${CLAUDE_PLUGIN_ROOT}/tools/validate-*.js`, making the plugin self-contained. `npx idd validate` remains available for CI and non-plugin contexts via the sibling `idd-toolkit` npm package.
+- Skills invoke bundled validators via `${CLAUDE_PLUGIN_ROOT}/tools/validate-*.js`, making the plugin self-contained. `npx idd validate` remains available for CI and non-plugin contexts via the sibling `idd-toolkit` npm package.
 - README installation section leads with the plugin install path; npm install is documented as the CI/dev alternative.
+- Existing per-document validators (`validate-models`, `validate-journey-maps`, `validate-capability-scope`, `validate-fixtures`) now run their schema before applying imperative checks. Schema errors surface as `schema: …` lines; behavior is strictly additive in 1.0.
 
 ### Removed
 
-- `tools/check-capability-scope.js`, `tools/check-front-matter.js`, `tools/check-traceability.js` — deprecated compatibility wrappers; use `validate-*` directly
-- `tools/link-skills.sh` — superseded by `idd install-skills --link`
-- `tools/build.sh` — plugin-zip build script; distribution is now directly via the plugin marketplace against a git checkout
-- `.github/workflows/release-claude-plugin.yml` — no longer builds a plugin zip release
-- `tools/package.json`, `tools/package-lock.json` — redundant private sub-package; root `idd-toolkit` owns dependencies
-- `WORKFLOW.md` — Symphony-orchestration experiment, no longer reflects repo workflow
+- `tools/check-capability-scope.js`, `tools/check-front-matter.js`, `tools/check-traceability.js` — deprecated compatibility wrappers; use `validate-*` directly.
+- `tools/link-skills.sh` — superseded by `idd install-skills --link`.
+- `tools/build.sh` — plugin-zip build script; distribution is now directly via the plugin marketplace against a git checkout.
+- `.github/workflows/release-claude-plugin.yml` — no longer builds a plugin zip release.
+- `tools/package.json`, `tools/package-lock.json` — redundant private sub-package; root `idd-toolkit` owns dependencies.
+- `WORKFLOW.md` — Symphony-orchestration experiment, no longer reflects repo workflow.
 
 ### Fixed
 
-- `validate fixtures`: nested `$ref` composition in `components.schemas`
-  (e.g. `allOf: [{ $ref: '#/components/schemas/Base' }, ...]`) now resolves
-  correctly in both the legacy `_meta.schema` path and the OpenAPI
-  `method/path` path. Previously the validator called `ajv.compile(schema)`
-  in isolation and failed with `can't resolve reference from id #`
-  whenever a named schema referenced a sibling component. The fix
-  pre-registers every `components.schemas.*` entry with its canonical
-  `#/components/schemas/<Name>` as `$id` so Ajv can resolve nested
-  references at compile time. Added regression test
-  `test/fixture-ref-resolution.test.js`.
+- `validate fixtures`: nested `$ref` composition in `components.schemas` (e.g. `allOf: [{ $ref: '#/components/schemas/Base' }, ...]`) now resolves correctly in both the legacy `_meta.schema` path and the OpenAPI `method/path` path. The fix pre-registers every `components.schemas.*` entry with its canonical `#/components/schemas/<Name>` as `$id` so Ajv can resolve nested references at compile time. Regression test in `test/fixture-ref-resolution.test.js`.
 
 ## [0.1.0] - 2026-03-07
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "idd-toolkit",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "Intention-Driven Design toolkit: skills, validators, and evidence generators for traceable software development.",
   "author": {
     "name": "Ted Slusser",


### PR DESCRIPTION
Promotes idd-toolkit (\`package.json\`) and idd-skills (\`.claude-plugin/plugin.json\`) to **1.0.0** and lands the matching CHANGELOG entry.

## What 1.0.0 represents

The IDD specification format now has a single normative source. The [#24 language-theoretic schema effort](https://github.com/slusset/intention-driven-design/issues/24) is complete:

- Per-document grammars in `schemas/v1/` with stable `\$id` URLs (#36)
- Closed-world key validation + `\$conformance` tiers (#37)
- Kinded grammars for relationships, actions, assertions (#38)
- Declarative lifecycle and journey-map shapes (#39)
- Reference closure as a capability-scope obligation (#40)
- Enforcement bindings on model rules (#41)

Plus the methodology additions from #42 (agent role, change process) and the packaging shifts from #34/#35 that retired the plugin-zip release in favor of git-checkout distribution.

## Why 1.0 now

The format is normative. Downstream adopters (humans, IDE tooling, AI assistants) can reason about IDD artifacts from a single source instead of re-implementing it implicitly. The previous "still iterating" signal of 0.x is no longer accurate.

## Versioning policy

- **Plugin/toolkit version** (this bump): tracks the methodology surface and release cadence.
- **Schema registry version** (currently `1.5.0` in `schemas/v1/index.json`): tracks the JSON Schema set independently per SCHEMA.md's semver policy. Schema minor bumps don't require plugin minor bumps.

After this merges I'll tag \`v1.0.0\` on main and cut a GitHub Release pointing at this PR and the #24 closing comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)