### PR TITLE
Register capability-closure and enforcement-bindings in the CLI and CI

### DIFF
--- a/.github/actions/idd-check/action.yml
+++ b/.github/actions/idd-check/action.yml
@@ -109,7 +109,7 @@ runs:
         # Determine which core checks to run
         CHECKS="${{ inputs.checks }}"
         if [ "$CHECKS" = "all" ]; then
-          CHECKS="contracts traceability front-matter capability-scope fixtures models journey-maps"
+          CHECKS="contracts traceability front-matter capability-scope capability-closure fixtures models enforcement-bindings journey-maps"
         fi
 
         # Run each core validator individually, capturing JSON per check
@@ -245,8 +245,10 @@ runs:
           'contracts': 'Contracts',
           'front-matter': 'Front-Matter',
           'capability-scope': 'Capability Scope',
+          'capability-closure': 'Capability Closure',
           'fixtures': 'Fixtures',
           'models': 'Models',
+          'enforcement-bindings': 'Enforcement Bindings',
           'journey-maps': 'Journey Maps',
           'evidence': 'Evidence',
         };

--- a/.github/actions/idd-check/action.yml
+++ b/.github/actions/idd-check/action.yml
@@ -511,8 +511,11 @@ runs:
         path: /tmp/idd-results/evidence/
         if-no-files-found: ignore
 
+    # Best-effort mirror of the job summary — a transient GitHub API error
+    # here must not fail the compliance verdict (Enforce failure carries it).
     - name: Post PR comment
       if: github.event_name == 'pull_request' && inputs.post-comment == 'true'
+      continue-on-error: true
       uses: actions/github-script@v7
       with:
         script: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — capability-closure and enforcement-bindings join the CLI and CI
+
+`tools/validate-capability-closure.js` (#40) and
+`tools/validate-enforcement-bindings.js` (#41) existed with tests but were
+never registered, so `idd validate` and CI could not run them. Both are now
+in the `VALIDATORS` map (`idd validate capability-closure`,
+`idd validate enforcement-bindings`, included in `idd validate all`) and in
+the `idd-check` action's default check list, giving rules/invariants
+enforcement the same CI report surface as the other validators. Both remain
+advisory-by-default: unbound (narrative/pending) rules and closure drift
+report as info/warnings unless a repo opts into `--strict`.
+
 ### Changed — certification evidence moves from committed artifacts to the CI report
 
 Evidence is derived output — recomputed from specs and test reports on every

--- a/README.md
+++ b/README.md
@@ -287,9 +287,11 @@ tools/                       Validators and generators
 ├── validate-front-matter.js Validate required/recommended metadata fields
 ├── validate-traceability.js Validate cross-artifact reference integrity
 ├── validate-capability-scope.js Validate capability scope coverage
+├── validate-capability-closure.js Validate capability scope as a reference closure
 ├── validate-contracts.js    Validate OpenAPI, AsyncAPI, and JSON-RPC contracts
 ├── validate-fixtures.js     Validate fixtures against protocol-specific contract schemas
 ├── validate-models.js       Validate model/lifecycle structural rules
+├── validate-enforcement-bindings.js Validate model rule enforced: bindings resolve to real artifacts
 ├── validate-journey-maps.js Validate journey map structural rules
 ├── generate-evidence.js     Generate certification evidence manifests (CI report input)
 ├── graph-generation/        Mermaid spec traceability graph generators
@@ -313,7 +315,7 @@ idd validate traceability front-matter --json
 idd validate fixtures models --strict
 ```
 
-Available validators: `contracts`, `traceability`, `front-matter`, `capability-scope`, `fixtures`, `models`, `journey-maps`, `evidence`.
+Available validators: `contracts`, `traceability`, `front-matter`, `capability-scope`, `capability-closure`, `fixtures`, `models`, `enforcement-bindings`, `journey-maps`, `evidence`.
 
 Common CLI options:
 - `--files <paths...>` limit checks to specific files

--- a/bin/idd.js
+++ b/bin/idd.js
@@ -42,8 +42,10 @@ function cmdValidate(argv) {
     traceability: 'validate-traceability.js',
     'front-matter': 'validate-front-matter.js',
     'capability-scope': 'validate-capability-scope.js',
+    'capability-closure': 'validate-capability-closure.js',
     fixtures: 'validate-fixtures.js',
     models: 'validate-models.js',
+    'enforcement-bindings': 'validate-enforcement-bindings.js',
     'journey-maps': 'validate-journey-maps.js',
     evidence: 'validate-evidence.js',
   };

--- a/test/validator-registration.test.js
+++ b/test/validator-registration.test.js
@@ -1,0 +1,39 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const IDD_BIN = path.join(REPO_ROOT, 'bin', 'idd.js');
+
+function runNode(args) {
+  return execFileSync(process.execPath, args, {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+  });
+}
+
+function runJson(args) {
+  return JSON.parse(runNode(args));
+}
+
+test('capability-closure and enforcement-bindings are registered validators', () => {
+  const listing = runNode([IDD_BIN, 'validate']);
+
+  assert.match(listing, /capability-closure/);
+  assert.match(listing, /enforcement-bindings/);
+});
+
+test('idd validate capability-closure passes on the example specs', () => {
+  const result = runJson([IDD_BIN, 'validate', 'capability-closure', '--json']);
+
+  assert.deepEqual(result.errors, []);
+  assert.match(result.info.join('\n'), /trade-show-signup\.capability\.yaml: closure OK/);
+});
+
+test('idd validate enforcement-bindings passes on the example specs', () => {
+  const result = runJson([IDD_BIN, 'validate', 'enforcement-bindings', '--json']);
+
+  assert.deepEqual(result.errors, []);
+  assert.match(result.info.join('\n'), /narrative enforced/);
+});


### PR DESCRIPTION
## Why

Follow-up from #52's notes. `tools/validate-capability-closure.js` (#40) and `tools/validate-enforcement-bindings.js` (#41) existed with tests and are listed in `schemas/v1/index.json` as cross-document constraints — but neither was registered in `bin/idd.js`'s VALIDATORS map or the `idd-check` action's default checks, so `idd validate` couldn't run them and no CI ever executed them. Teams adding rules and invariants got zero feedback on whether `enforced:` bindings resolve to real artifacts or capability scopes stay closed.

## What changed

- **`bin/idd.js`** — `capability-closure` and `enforcement-bindings` join the VALIDATORS map. Both are runnable individually (`idd validate enforcement-bindings`) and included in `idd validate all` (now 9 checks).
- **`idd-check` action** — both added to the default check list and the report label map (`Capability Closure`, `Enforcement Bindings`), so every PR's compliance table now carries a row for each. Rules/invariants enforcement gets the same CI report surface evidence gained in #52.
- **README** — validators reference and `tools/` tree updated.
- **Tests** — `test/validator-registration.test.js` pins the registration and a passing run on the example specs.

Both validators stay advisory-by-default, matching their design: narrative/pending `enforced:` rules and closure drift report as info/warnings unless a repo opts into `--strict` (the example models' `enforced: domain` narrative tags surface as info nudges, not failures).

## Verification

- `npm test`: 94/94 passing (3 new).
- `idd validate all`: 9/9 checks pass — both new validators run clean on the example specs (`closure OK (scope = 18, closure = 18)`; two narrative-binding info nudges).
- `action.yml` parses; the summary renderer needs no changes since per-check rows are label-driven.

## Note on the branch

The designated work branch was restarted from `main` after #52 merged, so this PR contains only this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DGEc8vLsYYKpi8LLYa7Xqn

---
_Generated by [Claude Code](https://claude.ai/code/session_01DGEc8vLsYYKpi8LLYa7Xqn)_