### PR TITLE
feat: add Codex skills plugin release

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "idd",
+  "interface": {
+    "displayName": "Intention-Driven Design"
+  },
+  "plugins": [
+    {
+      "name": "idd-skills",
+      "source": {
+        "source": "local",
+        "path": "./"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "idd-skills",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Intention-Driven Design methodology and technical skills. Narrative-first development: personas, journeys, stories, domain models, behavior contracts, and e2e journey testing. Bundles the idd validator CLI (bin/idd on PATH), tools, and schemas.",
   "author": {
     "name": "Ted Slusser",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,38 @@
+{
+  "name": "idd-skills",
+  "version": "1.3.0",
+  "description": "Core Intention-Driven Design skills and validation tooling for narrative-first, traceable software development.",
+  "author": {
+    "name": "Ted Slusser",
+    "url": "https://github.com/slusset"
+  },
+  "repository": "https://github.com/slusset/intention-driven-design",
+  "license": "MIT",
+  "keywords": [
+    "idd",
+    "intention-driven-design",
+    "narrative-driven",
+    "bdd",
+    "domain-modeling",
+    "traceability"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Intention-Driven Design",
+    "shortDescription": "Narrative-first skills and validation for traceable software",
+    "longDescription": "Turn human intent into traceable narratives, domain models, contracts, journey tests, and certification evidence. This Codex and ChatGPT surface includes the core IDD skills and the repository's validation tooling; stack-specific technical skills remain a separate Claude/legacy surface.",
+    "developerName": "Ted Slusser",
+    "category": "Productivity",
+    "capabilities": [
+      "Read",
+      "Write",
+      "Execute"
+    ],
+    "defaultPrompt": [
+      "Use IDD to turn this goal into traceable specs.",
+      "Run the IDD checks for this repository.",
+      "Review this change for traceability and evidence."
+    ],
+    "brandColor": "#3B82F6"
+  }
+}

--- a/.github/workflows/idd-check.yml
+++ b/.github/workflows/idd-check.yml
@@ -13,6 +13,8 @@ on:
       - 'skills/**'
       - 'technical-skills/**'
       - '.claude-plugin/**'
+      - '.codex-plugin/**'
+      - '.agents/plugins/**'
       - '.github/workflows/idd-check.yml'
       - '.github/actions/idd-check/**'
   push:
@@ -26,6 +28,8 @@ on:
       - 'skills/**'
       - 'technical-skills/**'
       - '.claude-plugin/**'
+      - '.codex-plugin/**'
+      - '.agents/plugins/**'
       - '.github/workflows/idd-check.yml'
       - '.github/actions/idd-check/**'
 
@@ -65,10 +69,13 @@ jobs:
       - name: Install Claude Code CLI
         run: npm install -g @anthropic-ai/claude-code
 
+      - name: Validate Codex/ChatGPT plugin manifest and bundled tooling
+        run: node tools/validate-plugin-manifests.js
+
       # Validating a bare skills directory behaves differently across CLI
-      # versions (components mode vs. plugin-root mode), so CI sticks to the
-      # two manifests; plugin-manifest validation already resolves each
-      # declared skills root.
+      # versions (components mode vs. plugin-root mode), so Claude CI sticks
+      # to the legacy manifests; the repository check above validates the
+      # Codex manifest and its core-only skills root.
       - name: Validate marketplace and plugin manifests
         run: |
           claude plugin validate --strict .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] - 2026-08-21
+
+### Added — ChatGPT / Codex skills-only plugin surface
+
+- Added `.codex-plugin/plugin.json` and a repo-scoped marketplace at
+  `.agents/plugins/marketplace.json` for the universal ChatGPT/Codex plugin
+  directory.
+- The Codex manifest loads only the core `skills/` directory; the existing
+  Claude plugin remains the surface that includes `technical-skills/`.
+- Added a dependency-free plugin/tooling manifest check and included it in the
+  local and GitHub validation paths.
+- Made the PR-review validator instructions portable across Codex and Claude
+  plugin roots.
+
 ## [1.2.0] - 2026-08-21
 
 ### Added — single standard Claude Code plugin: skills + technical skills + tools + schemas
@@ -181,4 +195,3 @@ The language-theoretic schema effort ([#24](https://github.com/slusset/intention
 ### Changed
 
 - `.github/workflows/idd-check.yml` simplified from ~400 lines to use the reusable action
-

--- a/README.md
+++ b/README.md
@@ -114,6 +114,26 @@ The narrative, model, and contract layers are completely technology-independent.
 
 ## Installation
 
+### As a ChatGPT / Codex plugin (core skills)
+
+The repo also exposes a Codex plugin through `.codex-plugin/plugin.json` and a
+repo-scoped marketplace at `.agents/plugins/marketplace.json`. This surface
+loads the core methodology skills from `skills/` and intentionally leaves out
+`technical-skills/`; the existing Claude plugin and legacy copy flow retain
+their current technical-skill behavior. The plugin source also carries the
+IDD CLI, validators, schemas, docs, and reusable GitHub Action.
+
+From a checkout:
+
+```bash
+codex plugin marketplace add .
+codex plugin add idd-skills@idd
+```
+
+In the ChatGPT desktop app, restart after adding the repo marketplace, then
+install `idd-skills` from the Intention-Driven Design marketplace. Use a new
+conversation after installation so the host loads the current skill set.
+
 ### As a Claude Code plugin (recommended)
 
 The repo is a self-contained Claude Code plugin — `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` are at the repo root. One install brings everything: the methodology skills (`skills/`), the stack-specific technical skills (`technical-skills/`), the schemas, and the `idd` validator CLI (the plugin's `bin/` is added to Bash PATH while active, so skills and you can run `idd validate all` with no separate install). Node dependencies install automatically from the committed lockfile.
@@ -135,6 +155,11 @@ For plugin development from a local checkout: `/plugin marketplace add ~/dev/idd
 npm install --save-dev github:slusset/intention-driven-design
 npx idd validate all          # run validators outside of Claude Code
 ```
+
+The npm package and both plugin manifests are versioned together by
+`just release <version>`. `just validate-plugin` checks the Codex/ChatGPT
+manifest, the core-only skills boundary, bundled tooling, and the existing
+Claude plugin manifests.
 
 ### Local development (from checkout)
 

--- a/justfile
+++ b/justfile
@@ -48,14 +48,15 @@ lint-openapi:
 lint-gherkin:
     npx gherkin-lint specs/features/
 
-# Validate the Claude Code plugin/marketplace manifests (matches the CI job)
+# Validate the Claude Code and Codex/ChatGPT plugin/marketplace manifests
 validate-plugin:
+    node tools/validate-plugin-manifests.js
     claude plugin validate --strict .
     claude plugin validate --strict .claude-plugin/plugin.json
 
-# Bump package.json and .claude-plugin/plugin.json in lockstep (e.g. `just release 1.2.0`)
+# Bump package.json and both plugin manifests in lockstep (e.g. `just release 1.2.0`)
 release version:
-    node -e "for (const f of ['package.json', '.claude-plugin/plugin.json']) { const fs = require('fs'); const data = JSON.parse(fs.readFileSync(f, 'utf8')); data.version = '{{version}}'; fs.writeFileSync(f, JSON.stringify(data, null, 2) + '\n'); console.log(f + ' -> {{version}}'); }"
+    node -e "for (const f of ['package.json', '.claude-plugin/plugin.json', '.codex-plugin/plugin.json']) { const fs = require('fs'); const data = JSON.parse(fs.readFileSync(f, 'utf8')); data.version = '{{version}}'; fs.writeFileSync(f, JSON.stringify(data, null, 2) + '\n'); console.log(f + ' -> {{version}}'); }"
     @echo ""
     @echo "Next steps:"
     @echo "  1. Move the [Unreleased] CHANGELOG entries under [{{version}}]"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "idd-toolkit",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Intention-Driven Design toolkit: skills, validators, and evidence generators for traceable software development.",
   "author": {
     "name": "Ted Slusser",
@@ -31,6 +31,9 @@
   },
   "files": [
     ".claude-plugin/",
+    ".codex-plugin/",
+    ".agents/plugins/marketplace.json",
+    ".github/actions/idd-check/",
     "bin/",
     "tools/lib/",
     "tools/validate-*.js",

--- a/skills/pr-review/SKILL.md
+++ b/skills/pr-review/SKILL.md
@@ -69,7 +69,7 @@ that violate the declared execution contract.
 
 ## Layer 1: Deterministic Checks
 
-These run without an LLM. They invoke validators bundled with this plugin at `${CLAUDE_PLUGIN_ROOT}/tools/validate-*.js`, scoped to the PR diff rather than the full repo. (In CI or outside the plugin, the same scripts are also available via `npx idd validate <name>` when `idd-toolkit` is installed.)
+These run without an LLM. The plugin bundles the validators under `tools/` and the `idd` CLI under `bin/`. Resolve the tool root from the active host (`PLUGIN_ROOT` for Codex when exposed, `CLAUDE_PLUGIN_ROOT` for Claude), use an `idd` already on `PATH`, or fall back to `npx idd` in CI/outside a plugin. Keep the checks scoped to the PR diff rather than the full repo.
 
 ### Check 1: Front-Matter Presence
 
@@ -94,8 +94,10 @@ See `docs/idd/front-matter-spec.md` for the full schema.
 
 Every `refs` path, `sources` path, `_meta.story`, `_meta.feature`, `# story:`, and `# journey:` value must point to a file that exists in the repo.
 
+If the active plugin host exposes its root, run the bundled validator with the corresponding root (`$PLUGIN_ROOT` in Codex or `$CLAUDE_PLUGIN_ROOT` in Claude); otherwise use:
+
 ```bash
-node "${CLAUDE_PLUGIN_ROOT}/tools/validate-traceability.js" --json
+npx idd validate traceability --json
 ```
 
 **Pass criteria**: Zero broken links (exit code 0).

--- a/test/plugin-manifest.test.js
+++ b/test/plugin-manifest.test.js
@@ -8,10 +8,37 @@ const REPO_ROOT = path.resolve(__dirname, '..');
 const pkg = require(path.join(REPO_ROOT, 'package.json'));
 const pluginManifest = require(path.join(REPO_ROOT, '.claude-plugin', 'plugin.json'));
 const marketplace = require(path.join(REPO_ROOT, '.claude-plugin', 'marketplace.json'));
+const codexManifest = require(path.join(REPO_ROOT, '.codex-plugin', 'plugin.json'));
+const codexMarketplace = require(path.join(REPO_ROOT, '.agents', 'plugins', 'marketplace.json'));
 
 test('plugin.json version stays in lockstep with package.json', () => {
   assert.equal(pluginManifest.version, pkg.version,
     'Bump both with `just release <version>` — plugin users only see updates when plugin.json changes');
+  assert.equal(codexManifest.version, pkg.version,
+    'Bump all three with `just release <version>` — Codex plugin users need the new manifest version');
+});
+
+test('Codex manifest exposes core skills only', () => {
+  assert.equal(codexManifest.skills, './skills/');
+  assert.doesNotMatch(JSON.stringify(codexManifest), /technical-skills/);
+  assert.equal(codexManifest.interface.displayName, 'Intention-Driven Design');
+});
+
+test('repo marketplace exposes the Codex plugin with explicit install policy', () => {
+  const entry = codexMarketplace.plugins.find((p) => p.name === codexManifest.name);
+  assert.ok(entry, `marketplace.json has no entry for plugin '${codexManifest.name}'`);
+  assert.deepEqual(entry.source, { source: 'local', path: './' });
+  assert.deepEqual(entry.policy, { installation: 'AVAILABLE', authentication: 'ON_INSTALL' });
+  assert.equal(entry.category, 'Productivity');
+});
+
+test('repository plugin manifest/tooling gate passes', () => {
+  const output = execFileSync(process.execPath, [
+    path.join(REPO_ROOT, 'tools', 'validate-plugin-manifests.js'),
+    '--json',
+  ], { cwd: REPO_ROOT, encoding: 'utf8' });
+  const result = JSON.parse(output);
+  assert.equal(result.ok, true, result.errors.join('\n'));
 });
 
 test('marketplace entry names match and only one place declares a version', () => {

--- a/tools/validate-plugin-manifests.js
+++ b/tools/validate-plugin-manifests.js
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const PACKAGE_PATH = path.join(REPO_ROOT, 'package.json');
+const CODEX_MANIFEST_PATH = path.join(REPO_ROOT, '.codex-plugin', 'plugin.json');
+const MARKETPLACE_PATH = path.join(REPO_ROOT, '.agents', 'plugins', 'marketplace.json');
+
+const errors = [];
+const warnings = [];
+const info = [];
+
+function readJson(filePath, label) {
+  if (!fs.existsSync(filePath)) {
+    errors.push(`${label} is missing: ${path.relative(REPO_ROOT, filePath)}`);
+    return null;
+  }
+
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch (error) {
+    errors.push(`${label} is not valid JSON: ${error.message}`);
+    return null;
+  }
+}
+
+function requireString(value, label) {
+  if (typeof value !== 'string' || value.trim() === '') {
+    errors.push(`${label} must be a non-empty string`);
+    return false;
+  }
+  return true;
+}
+
+function requireFile(relativePath, label) {
+  if (!fs.existsSync(path.join(REPO_ROOT, relativePath))) {
+    errors.push(`${label} is missing: ${relativePath}`);
+  }
+}
+
+function validateCodexManifest(pkg) {
+  const manifest = readJson(CODEX_MANIFEST_PATH, 'Codex plugin manifest');
+  if (!manifest) return;
+
+  requireString(manifest.name, 'Codex plugin name');
+  requireString(manifest.version, 'Codex plugin version');
+  requireString(manifest.description, 'Codex plugin description');
+  if (manifest.name !== 'idd-skills') {
+    errors.push(`Codex plugin name must be idd-skills, got ${manifest.name}`);
+  }
+  if (manifest.version !== pkg.version) {
+    errors.push(`Codex plugin version ${manifest.version} does not match package.json ${pkg.version}`);
+  }
+
+  if (manifest.skills !== './skills/') {
+    errors.push('Codex plugin skills must be exactly ./skills/');
+  }
+  if (JSON.stringify(manifest).includes('technical-skills')) {
+    errors.push('Codex plugin manifest must not declare technical-skills');
+  }
+
+  const interfaceMetadata = manifest.interface;
+  if (!interfaceMetadata || typeof interfaceMetadata !== 'object') {
+    errors.push('Codex plugin interface metadata is missing');
+  } else {
+    for (const field of ['displayName', 'shortDescription', 'longDescription', 'developerName', 'category']) {
+      requireString(interfaceMetadata[field], `Codex plugin interface.${field}`);
+    }
+    if (!Array.isArray(interfaceMetadata.capabilities) || interfaceMetadata.capabilities.length === 0) {
+      errors.push('Codex plugin interface.capabilities must be a non-empty array');
+    }
+    if (!Array.isArray(interfaceMetadata.defaultPrompt) || interfaceMetadata.defaultPrompt.length === 0) {
+      errors.push('Codex plugin interface.defaultPrompt must be a non-empty array');
+    }
+  }
+
+  const skillsRoot = path.join(REPO_ROOT, 'skills');
+  const skillDirs = fs.existsSync(skillsRoot)
+    ? fs.readdirSync(skillsRoot, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name)
+    : [];
+  if (skillDirs.length === 0) {
+    errors.push('Codex plugin skills root contains no skill directories');
+  }
+  for (const skillName of skillDirs) {
+    if (!fs.existsSync(path.join(skillsRoot, skillName, 'SKILL.md'))) {
+      errors.push(`Codex skill ${skillName} is missing SKILL.md`);
+    }
+  }
+}
+
+function validateMarketplace() {
+  const marketplace = readJson(MARKETPLACE_PATH, 'Codex repo marketplace');
+  if (!marketplace) return;
+
+  requireString(marketplace.name, 'Marketplace name');
+  if (!marketplace.interface || typeof marketplace.interface !== 'object') {
+    errors.push('Marketplace interface metadata is missing');
+  } else {
+    requireString(marketplace.interface.displayName, 'Marketplace interface.displayName');
+  }
+
+  if (!Array.isArray(marketplace.plugins)) {
+    errors.push('Marketplace plugins must be an array');
+    return;
+  }
+
+  const entry = marketplace.plugins.find((plugin) => plugin && plugin.name === 'idd-skills');
+  if (!entry) {
+    errors.push('Marketplace has no idd-skills entry');
+    return;
+  }
+  if (!entry.source || entry.source.source !== 'local' || entry.source.path !== './') {
+    errors.push('Marketplace idd-skills entry must point to the local repo root with ./');
+  }
+  if (!entry.policy || entry.policy.installation !== 'AVAILABLE' || entry.policy.authentication !== 'ON_INSTALL') {
+    errors.push('Marketplace idd-skills entry has an invalid installation policy');
+  }
+  requireString(entry.category, 'Marketplace idd-skills category');
+}
+
+function validateTooling() {
+  requireFile('bin/idd.js', 'IDD CLI');
+  requireFile('bin/idd', 'IDD PATH shim');
+  requireFile('.github/actions/idd-check/action.yml', 'IDD GitHub Action');
+  requireFile('schemas/v1/index.json', 'IDD schema registry');
+
+  const validatorCount = fs.readdirSync(path.join(REPO_ROOT, 'tools'))
+    .filter((name) => name.startsWith('validate-') && name.endsWith('.js'))
+    .length;
+  if (validatorCount === 0) {
+    errors.push('No IDD validators are bundled under tools/');
+  } else {
+    info.push(`Bundled ${validatorCount} IDD validators`);
+  }
+}
+
+const pkg = readJson(PACKAGE_PATH, 'package.json');
+if (pkg) validateCodexManifest(pkg);
+validateMarketplace();
+validateTooling();
+
+const result = {
+  ok: errors.length === 0,
+  errors,
+  warnings,
+  info,
+};
+
+if (process.argv.includes('--json')) {
+  console.log(JSON.stringify(result, null, 2));
+} else {
+  for (const line of info) console.log(`INFO: ${line}`);
+  for (const line of warnings) console.warn(`WARN: ${line}`);
+  for (const line of errors) console.error(`ERROR: ${line}`);
+  console.log(result.ok ? 'Plugin manifest validation passed.' : 'Plugin manifest validation failed.');
+}
+
+process.exit(result.ok ? 0 : 1);


### PR DESCRIPTION
## Summary

- Add the Codex/ChatGPT-compatible `.codex-plugin/plugin.json` manifest and repo-scoped marketplace.
- Expose only the core `skills/` directory in the Codex surface; retain `technical-skills/` for the existing Claude/npm surface.
- Include the IDD CLI, validators, schemas, reusable GitHub Action, and a dependency-free plugin/tooling manifest gate.
- Update release versioning, docs, CI paths, and PR-review validator instructions for both plugin hosts.

## Verification

- `npm test` — 101/101 passing
- `just ci` — 9/9 checks passing
- `just validate-plugin` — repository Codex gate and Claude strict validation passing
- npm package dry-run — required plugin, marketplace, CLI, validator, and action files present

Release version: `1.3.0`